### PR TITLE
Cambiar entity id por increment

### DIFF
--- a/Controller/Transaction/CommitWebpayM22.php
+++ b/Controller/Transaction/CommitWebpayM22.php
@@ -276,7 +276,7 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action
     protected function getOrder($orderId)
     {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        return $objectManager->create('\Magento\Sales\Model\Order')->load($orderId);
+        return $objectManager->create('\Magento\Sales\Model\Order')->loadByIncrementId($orderId);
     }
     /**
      * @param $tokenWs

--- a/Controller/Transaction/CreateWebpayM22.php
+++ b/Controller/Transaction/CreateWebpayM22.php
@@ -85,7 +85,7 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action
             $this->checkoutSession->setLastQuoteId($quote->getId());
             $this->checkoutSession->setLastSuccessQuoteId($quote->getId());
             $this->checkoutSession->setLastOrderId($order->getId());
-            $this->checkoutSession->setLastRealOrderId($order->getEntityId());
+            $this->checkoutSession->setLastRealOrderId($order->getIncrementId());
             $this->checkoutSession->setLastOrderStatus($order->getStatus());
             $this->checkoutSession->setGrandTotal($grandTotal);
 


### PR DESCRIPTION
Magento visualmente en todo momento, ya sea en el administrador (back-office) y a los usuarios, identifica una orden con el incrementID, por lo que en posibles operaciones podrían exisitir inconsistencias ya que mirando magento, por ejemplo, una orden no tendra el mismo número en transbank.