### PR TITLE
Agregar titulo al medio de pago

### DIFF
--- a/Controller/Transaction/CommitWebpayM22.php
+++ b/Controller/Transaction/CommitWebpayM22.php
@@ -276,7 +276,7 @@ class CommitWebpayM22 extends \Magento\Framework\App\Action\Action
     protected function getOrder($orderId)
     {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        return $objectManager->create('\Magento\Sales\Model\Order')->load($orderId);
+        return $objectManager->create('\Magento\Sales\Model\Order')->loadByIncrementId($orderId);
     }
     /**
      * @param $tokenWs

--- a/Controller/Transaction/CreateWebpayM22.php
+++ b/Controller/Transaction/CreateWebpayM22.php
@@ -85,7 +85,7 @@ class CreateWebpayM22 extends \Magento\Framework\App\Action\Action
             $this->checkoutSession->setLastQuoteId($quote->getId());
             $this->checkoutSession->setLastSuccessQuoteId($quote->getId());
             $this->checkoutSession->setLastOrderId($order->getId());
-            $this->checkoutSession->setLastRealOrderId($order->getEntityId());
+            $this->checkoutSession->setLastRealOrderId($order->getIncrementId());
             $this->checkoutSession->setLastOrderStatus($order->getStatus());
             $this->checkoutSession->setGrandTotal($grandTotal);
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -3,6 +3,11 @@
         <section id="payment">
             <group id="transbank_webpay" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Transbank Webpay Plus REST</label>
+                
+                 <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Payment Title</label>
+                    <config_path>payment/transbank_webpay/title</config_path>
+                </field>
 
                 <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Habilitado</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -3,18 +3,18 @@
         <section id="payment">
             <group id="transbank_webpay" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Transbank Webpay Plus REST</label>
-                
-                 <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Payment Title</label>
-                    <config_path>payment/transbank_webpay/title</config_path>
-                </field>
 
                 <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Habilitado</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
 
-                <group id="general_parameters" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="title" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Payment Title</label>
+                    <config_path>payment/transbank_webpay/title</config_path>
+                </field>
+
+                <group id="general_parameters" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Parámetros Generales</label>
                     <attribute type="expanded">0</attribute>
 
@@ -40,7 +40,7 @@
                         <comment>Posición en la que aparecerá la opción de pago, debe ser menor a otros medios de pago para que aparezca primero</comment>
                     </field>
                 </group>
-                <group id="security" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0">
+                <group id="security" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Parámetros de seguridad</label>
                     <attribute type="expanded">0</attribute>
 
@@ -62,7 +62,7 @@
                         <comment>Llave secreta utilizada para conectarse a la API ¡asegúrate de no compartir su contenido!</comment>
                     </field>
                 </group>
-                <group id="diagnostics" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="0">
+                <group id="diagnostics" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Herramientas de diagnóstico</label>
                     <attribute type="expanded">0</attribute>
                     <field id="tbk_button" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="09" translate="label" type="button">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,6 +4,7 @@
         <payment>
             <transbank_webpay>
                 <model>Transbank\Webpay\Model\Webpay</model>
+                <title translate="label">WebPay</title>
                 <active>1</active>
                 <general_parameters>
                     <payment_successful_status>complete</payment_successful_status>


### PR DESCRIPTION
En el listado de pedidos, correos o donde se trate de imprimir el medio de pago, no se ve, esto lo muestra y deja editable en el admin.