### PR TITLE
Prepare release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [1.1.2] - 2021-04-30
+## Fixed
+- Se corrige versión de SDK de PHP requerida para el plugin. Esto soluciona error al redireccionar a la pasarela de pago.
+
 # [1.1.1] - 2021-04-29
 ## Fixed
 - Se corrigen errores de compatibilidad con PHP 7.0.

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Transbank_Webpay" setup_version="1.1.1">
+    <module name="Transbank_Webpay" setup_version="1.1.2">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
## Fixed
- Se corrige versión de SDK de PHP requerida para el plugin. Esto soluciona error al redireccionar a la pasarela de pago.
