### PR TITLE
Remplazar Zend\Log\Logger para usar Magento 2.4.3

### DIFF
--- a/Model/LogHandler.php
+++ b/Model/LogHandler.php
@@ -344,18 +344,18 @@ class LogHandler
     {
         switch ($priority) {
             case 'error':
-                $prior = \Zend\Log\Logger::ERR;
+                $prior = \Monolog\Logger::ERROR;
             break;
             case 'info':
-                $prior = \Zend\Log\Logger::INFO;
+                $prior = \Monolog\Logger::INFO;
             break;
             default:
-                $prior = \Zend\Log\Logger::DEBUG;
+                $prior = \Monolog\Logger::DEBUG;
             break;
         }
-        $writer = new \Zend\Log\Writer\Stream($this->logFile);
-        $logger = new \Zend\Log\Logger();
-        $logger->addWriter($writer);
+        $logger = new \Monolog\Logger($this->logFile);
+        $writer = new \Monolog\Handler\StreamHandler($this->logFile, $prior);
+        $logger->pushHandler($writer);
         $logger->log($prior, $msg);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "ext-json": "*",
     "transbank/transbank-sdk": "~2.0",
     "tecnickcom/tcpdf": "^6.3",
-    "monolog/monolog": "^2.3"
+    "monolog/monolog": "1.17"
   },
   "type": "magento2-module",
   "archive": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "require": {
     "ext-json": "*",
     "transbank/transbank-sdk": "~2.0",
-    "tecnickcom/tcpdf": "^6.3"
+    "tecnickcom/tcpdf": "^6.3",
+    "monolog/monolog": "^2.3"
   },
   "type": "magento2-module",
   "archive": {


### PR DESCRIPTION
---
name: Remplazar Zend\Log\Logger para usar Magento 2.4.3
about: \Zend\Log\Logger ya no existe
title: ''
labels: bug
assignees: ''

---

**Describe el bug**

Al usar Magento 2.3.4 ya biblioteca Zend ya no es usada ya que esta cambio y el plugin hace
referencias Zend\Log\Logger que puede ser remplazado por MonoLog

**Para reproducir**

1) Instalar Magento 2.3.4 y el plugin
2) Realizar una compra con Webpay

**Comportamiento observado**

Al no existir la clase Zend\Log\Logger PHP entrega un error fatal error.

**Comportamiento esperado**

Se pueda comprar y generar en log.


**Versiones (por favor agrega aquí la siguiente información):**
- Plugin: 1.1
- Magento: 2.4
- PHP 7.4 y 7.3
