### PR TITLE
Magento 2.4.3-p1 utiliza Monolog 1.17 y transbank/webpay-magento2-rest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "ext-json": "*",
     "transbank/transbank-sdk": "~2.0",
     "tecnickcom/tcpdf": "^6.3",
-    "monolog/monolog": "1.25"
+    "monolog/monolog": ">=1.17"
   },
   "type": "magento2-module",
   "archive": {


### PR DESCRIPTION
---
name: Monolog versión 1.17
about: Utilizar versiones de Monolog igual o superior a la 1.17
title: ''
labels: bug
assignees: ''

---

**Describe el bug**

Magento 2.4.3-p2 utiliza monolog en su versión 1.17 y el plugin transbank/webpay-magento2-rest
utiliza monolog versión 1.25 por lo que composer require del plugin utiliza la version 1.1.2 como
candidata y no la version 1.1.3 que es la última versión del plugin.

**Para reproducir**

1. Instalar Magento 2.4
2. Instalar transbank/webpay-magento2-rest
3. Revisar la versión de transbank/webpay-magento2-rest
4. Comprar

**Comportamiento observado**

No se puede comprar al intentar finalizar la compra por el siguiente error:

Error: Class 'Zend\Log\Logger' not found in /app/vendor/transbank/webpay-magento2-rest/Model/LogHandler.php:350

**Comportamiento esperado**

Comprar con Transbank

**Capturas de pantalla**

Si aplica, agrega aquí capturas de pantalla que ayuden a explicar tu problema.

**Versiones (por favor agrega aquí la siguiente información):**
- Plugin: 1.1.3
- Magento: 2.4.3-p2
- PHP 7.4

**Contexto adicional**

Esto es aplicable para versiones de magento 2.3 y 2.2