### PR TITLE
Upgrade Schema Issue Fixed

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -22,11 +22,6 @@ class UpgradeSchema implements UpgradeSchemaInterface
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
         $setup->startSetup();
-        if (version_compare($context->getVersion(), '3.3.0', '<')) {
-            $setup->endSetup();
-
-            return;
-        }
 
         $webPayTable = $setup->getTable(WebpayOrderData::TABLE_NAME);
         if ($setup->getConnection()->isTableExists($webPayTable) === false) {


### PR DESCRIPTION
The error in the upgrade schema file does not allow the database to be upgrated.

[Full Diff...](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/compare/fix/upgrade-schema-issue)