### PR TITLE
fix: oneclick max amount default

### DIFF
--- a/Observer/OneclickAvailable.php
+++ b/Observer/OneclickAvailable.php
@@ -24,11 +24,12 @@ class OneclickAvailable implements ObserverInterface
 
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
         $customerSession = $objectManager->get('Magento\Customer\Model\Session');
-        $cart = $objectManager->get('\Magento\Checkout\Model\Cart'); 
+        $cart = $objectManager->get('\Magento\Checkout\Model\Cart');
 
         $grandTotal = $cart->getQuote()->getGrandTotal();
 
-        if ($customerSession->isLoggedIn() == false || $grandTotal >= $oneclickMaxAmount) {
+        if ($customerSession->isLoggedIn() == false || ($oneclickMaxAmount > 0
+            && $grandTotal >= $oneclickMaxAmount)) {
             $this->_logger->debug("User is not logged in");
 
             if($observer->getEvent()->getMethodInstance()->getCode() == "transbank_oneclick"){

--- a/Observer/OneclickAvailable.php
+++ b/Observer/OneclickAvailable.php
@@ -7,14 +7,14 @@ use Magento\Framework\Event\ObserverInterface;
 class OneclickAvailable implements ObserverInterface
 {
     protected $configProvider;
-    protected $_logger;
+    protected $logger;
     protected $shippingMethod;
 
     public function __construct (
         \Psr\Log\LoggerInterface $logger,
         \Transbank\Webpay\Model\Config\ConfigProvider $configProvider)
     {
-        $this->_logger = $logger;
+        $this->logger = $logger;
         $this->configProvider = $configProvider;
     }
 
@@ -30,7 +30,7 @@ class OneclickAvailable implements ObserverInterface
 
         if ($customerSession->isLoggedIn() == false || ($oneclickMaxAmount > 0
             && $grandTotal >= $oneclickMaxAmount)) {
-            $this->_logger->debug("User is not logged in");
+            $this->logger->debug("User is not logged in");
 
             if($observer->getEvent()->getMethodInstance()->getCode() == "transbank_oneclick"){
                 $checkResult = $observer->getEvent()->getResult();

--- a/Observer/OneclickAvailable.php
+++ b/Observer/OneclickAvailable.php
@@ -30,7 +30,7 @@ class OneclickAvailable implements ObserverInterface
 
         if ($customerSession->isLoggedIn() == false || ($oneclickMaxAmount > 0
             && $grandTotal >= $oneclickMaxAmount)) {
-            $this->logger->debug("User is not logged in");
+            $this->logger->debug("Onelick is not available");
 
             if($observer->getEvent()->getMethodInstance()->getCode() == "transbank_oneclick"){
                 $checkResult = $observer->getEvent()->getResult();

--- a/Observer/OneclickAvailable.php
+++ b/Observer/OneclickAvailable.php
@@ -30,7 +30,7 @@ class OneclickAvailable implements ObserverInterface
 
         if ($customerSession->isLoggedIn() == false || ($oneclickMaxAmount > 0
             && $grandTotal >= $oneclickMaxAmount)) {
-            $this->logger->debug("Onelick is not available");
+            $this->logger->debug("Oneclick is not available");
 
             if($observer->getEvent()->getMethodInstance()->getCode() == "transbank_oneclick"){
                 $checkResult = $observer->getEvent()->getResult();

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -163,7 +163,13 @@
                     <!-- Transaction Max Amount -->
                     <field id="transaction_max_amount" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Monto máximo de transacción permitido</label>
-                        <comment>El monto máximo por transacción para Transbank es ajeno al que se establezca en esta configuración.</comment>
+                        <comment>Define el monto máximo que un cliente puede pagar con Oneclick.
+                            Si un cliente va a realizar una compra superior a este monto, Oneclick no aparecerá como opción de
+                            pago en el proceso de checkout. Dejar en 0 si no se desea tener un límite (no recomendado). Recuerda que en
+                            Oneclick, al no contar con autentificación bancaria, es tu comercio el que asume el riesgo en caso de
+                            fraude o contracargo. Independiente del monto que definas en esta configuración, en tu
+                            contrato de Oneclick, existe un límite de cantidad de transacciones diarias, un monto máximo por
+                            transacción y monto acumulado diario. Si un cliente supera ese límite, su transacción será rechazada. </comment>
                     </field>
 
                     <!-- Api Key -->


### PR DESCRIPTION
* the default value is 0 and it does not restrict the maximum amount
* improve Oneclick maximum amount description (equal to Woocommerce)

![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/7391252/9083bc72-6275-4ff2-a214-a56995accbf9)
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/7391252/6c50e8e7-997c-4f4f-b011-abdcbaca2ddd)
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/7391252/d3307451-5c2b-465b-8bef-f0df5bc03d78)
