### PR TITLE
fix: add missing semicolon

### DIFF
--- a/Observer/SaveConfigObserver.php
+++ b/Observer/SaveConfigObserver.php
@@ -3,7 +3,7 @@
 namespace Transbank\Webpay\Observer;
 
 use GuzzleHttp\Client;
-use Magento\Framework\Module\ModuleList
+use Magento\Framework\Module\ModuleList;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\App\RequestInterface;


### PR DESCRIPTION
This PR add a missing semicolon in SaveConfigObserver file.

## Test

### Install plugin Ok

<img width="1050" alt="image" src="https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/9424708b-75a2-4f7c-8d8b-357ff2c39c3d">
