### PR TITLE
fix: duplicated view for oneclick payment methods

### DIFF
--- a/Controller/Oneclick/Index.php
+++ b/Controller/Oneclick/Index.php
@@ -2,10 +2,11 @@
 
 namespace Transbank\Webpay\Controller\Oneclick;
 
+use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\View\Result\PageFactory;
 
-class Index extends \Magento\Framework\App\Action\Action
+class Index extends Action
 {
     protected $resultPageFactory;
 
@@ -19,6 +20,6 @@ class Index extends \Magento\Framework\App\Action\Action
     {
         $this->_view->loadLayout();
         $this->_view->renderLayout();
-        return $this->resultPageFactory->create();
+        $this->resultPageFactory->create();
     }
 }

--- a/Controller/Oneclick/Index.php
+++ b/Controller/Oneclick/Index.php
@@ -1,10 +1,11 @@
 <?php
- 
+
 namespace Transbank\Webpay\Controller\Oneclick;
+
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\View\Result\PageFactory;
- 
-class Index extends \Magento\Framework\App\Action\Action 
+
+class Index extends \Magento\Framework\App\Action\Action
 {
     protected $resultPageFactory;
 
@@ -14,7 +15,7 @@ class Index extends \Magento\Framework\App\Action\Action
         $this->resultPageFactory = $resultPageFactory;
     }
 
-    public function execute() 
+    public function execute()
     {
         $this->_view->loadLayout();
         $this->_view->renderLayout();

--- a/view/frontend/layout/checkout_oneclick_index.xml
+++ b/view/frontend/layout/checkout_oneclick_index.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <update handle="customer_account"/> 
-    <body> 
-        <referenceBlock name="page.main.title"> 
-            <action method="setPageTitle"> 
-                <argument translate="true" name="title" xsi:type="string">Oneclick Payment Methods</argument> 
-            </action> 
-        </referenceBlock> 
-        <referenceContainer name="content"> 
-            <block class="Transbank\Webpay\Block\Oneclick" name="oneclick" template="Transbank_Webpay::cards.phtml" cacheable="false"/>/>
-        </referenceContainer> 
-    </body> 
+    <update handle="customer_account"/>
+    <body>
+        <referenceBlock name="page.main.title">
+            <action method="setPageTitle">
+                <argument translate="true" name="title" xsi:type="string">Oneclick Payment Methods</argument>
+            </action>
+        </referenceBlock>
+        <referenceContainer name="content">
+            <block class="Transbank\Webpay\Block\Oneclick" name="oneclick" template="Transbank_Webpay::cards.phtml" cacheable="false"/>
+        </referenceContainer>
+    </body>
 </page>


### PR DESCRIPTION
This PR resolves an issue that was causing the duplication of the one-click payment methods view.

## Test

### Before
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/52d42dfc-9b5e-4b62-a57f-a497a338ff4f)


### After
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/9984d97d-0be1-4c71-ab37-1abe29b7ed80)
