### PR TITLE
refactor: remove unused import

### DIFF
--- a/Observer/SaveConfigObserver.php
+++ b/Observer/SaveConfigObserver.php
@@ -2,18 +2,14 @@
 
 namespace Transbank\Webpay\Observer;
 
-use GuzzleHttp\Client;
-use Magento\Framework\Module\ModuleList;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use \Psr\Log\LoggerInterface;
-use Transbank\Webpay\Helper\ObjectManagerHelper;
 
 class SaveConfigObserver implements ObserverInterface
 {


### PR DESCRIPTION
This PR removes unused imports on save config observer

![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/101830551/e6a7b270-fac9-4976-8db5-58d559543fcf)

![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/101830551/7a97430e-80d6-432d-ade1-62c3ef60707c)

![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/101830551/824b38a8-699e-48e4-a4cb-3ee8ff7342da)
