### PR TITLE
fix: use configured credetials for connection test

### DIFF
--- a/Block/System/Config/TbkButton.php
+++ b/Block/System/Config/TbkButton.php
@@ -34,8 +34,6 @@ class TbkButton extends \Magento\Config\Block\System\Config\Form\Field
 
         $this->tbk_data = [
             'url_request'             => $context->getUrlBuilder()->getUrl('admin_webpay/Request/index'),
-            'url_create_pdf_report'   => $context->getUrlBuilder()->getUrl('admin_webpay/CreatePdf/index').'?document=report',
-            'url_create_pdf_php_info' => $context->getUrlBuilder()->getUrl('admin_webpay/CreatePdf/index').'?document=php_info',
             'php_status'              => $datos_hc['server_resume']['php_version']['status'],
             'php_version'             => $datos_hc['server_resume']['php_version']['version'],
             'server_version'          => $datos_hc['server_resume']['server_version']['server_software'],

--- a/Model/HealthCheck.php
+++ b/Model/HealthCheck.php
@@ -79,8 +79,6 @@ class HealthCheck
      */
     public function __construct($config)
     {
-        $config['COMMERCE_CODE'] = WebpayPlus::DEFAULT_COMMERCE_CODE;
-        $config['API_KEY'] = WebpayPlus::DEFAULT_API_KEY;
         $this->config = $config;
         $this->environment = $config['ENVIRONMENT'];
         $this->commerceCode = $config['COMMERCE_CODE'];


### PR DESCRIPTION
This PR fixes an issue in the communication test.

## Test

### Communication Test Ok in production
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/d83fa35f-4c16-48d8-9c84-c30ee41e02d3) 
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/87572c8e-d703-4b6c-94dd-66b6dae80714)

### Communication Test Ok in integration
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/67d04c2b-93e4-41c4-833b-62529bc5f176)
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/59798a2b-324d-4070-95da-53f1e9ef1d18)
