### PR TITLE
fix: oneclick authorization information database logging

### DIFF
--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -8,11 +8,9 @@ use Transbank\Webpay\Model\Oneclick;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\ObjectManager;
-use Magento\Quote\Model\QuoteManagement;
 use Transbank\Webpay\Helper\PluginLogger;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Json;
-use Magento\Store\Model\StoreManagerInterface;
 use Transbank\Webpay\Model\Config\ConfigProvider;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Controller\ResultInterface;
@@ -41,8 +39,6 @@ class AuthorizeOneclick extends Action
     private $cart;
     private $checkoutSession;
     private $resultJsonFactory;
-    private $quoteManagement;
-    private $storeManager;
     private $oneclickInscriptionDataFactory;
     private $log;
     private $webpayOrderDataFactory;
@@ -55,8 +51,6 @@ class AuthorizeOneclick extends Action
      * @param Cart $cart
      * @param Session $checkoutSession
      * @param JsonFactory $resultJsonFactory
-     * @param QuoteManagement $quoteManagement
-     * @param StoreManagerInterface $storeManager
      * @param ConfigProvider $configProvider
      * @param OneclickInscriptionDataFactory $oneclickInscriptionDataFactory
      * @param WebpayOrderDataFactory $webpayOrderDataFactory
@@ -67,8 +61,6 @@ class AuthorizeOneclick extends Action
         Cart $cart,
         Session $checkoutSession,
         JsonFactory $resultJsonFactory,
-        QuoteManagement $quoteManagement,
-        StoreManagerInterface $storeManager,
         ConfigProvider $configProvider,
         OneclickInscriptionDataFactory $oneclickInscriptionDataFactory,
         WebpayOrderDataFactory $webpayOrderDataFactory,
@@ -79,8 +71,6 @@ class AuthorizeOneclick extends Action
         $this->cart = $cart;
         $this->checkoutSession = $checkoutSession;
         $this->resultJsonFactory = $resultJsonFactory;
-        $this->quoteManagement = $quoteManagement;
-        $this->storeManager = $storeManager;
         $this->configProvider = $configProvider;
         $this->messageManager = $messageManager;
         $this->oneclickInscriptionDataFactory = $oneclickInscriptionDataFactory;

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -283,7 +283,7 @@ class AuthorizeOneclick extends Action
         $webpayOrderData->setData([
             'buy_order'       => $authorizeResponse->getBuyOrder(),
             'child_buy_order' => $authorizeResponse->getDetails()[0]->getBuyOrder(),
-            'commerce_code'   => $authorizeResponse->getDetails()[0]->getCommerceCode(),
+            'commerce_code'   => $this->oneclickConfig['COMMERCE_CODE'],
             'child_commerce_code'   => $authorizeResponse->getDetails()[0]->getCommerceCode(),
             'payment_status'  => $payment_status,
             'order_id'        => $order_id,

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -291,6 +291,7 @@ class AuthorizeOneclick extends Action
             'amount'          => $amount,
             'metadata'        => json_encode($authorizeResponse),
             'environment'     => $this->oneclickConfig['ENVIRONMENT'],
+            'product'         => Oneclick::PRODUCT_NAME
         ]);
         $webpayOrderData->save();
 

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -121,12 +121,6 @@ class AuthorizeOneclick extends Action
 
             $transbankSdkWebpay = new TransbankSdkWebpayRest($this->oneclickConfig);
 
-            $this->log->logError(json_encode($order));
-
-            $this->log->logError($this->oneclickConfig['CHILD_COMMERCE_CODE']);
-            $this->log->logError($orderId);
-            $this->log->logError($grandTotal);
-
             $buyOrder = "100000" . $orderId;
             $childBuyOrder = "200000" . $orderId;
 

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -45,6 +45,7 @@ class AuthorizeOneclick extends Action
     protected $oneclickInscriptionDataFactory;
     protected $log;
     protected $webpayOrderDataFactory;
+    private $messageManager;
 
     /**
      * AuthorizeOneclick constructor.
@@ -58,6 +59,7 @@ class AuthorizeOneclick extends Action
      * @param ConfigProvider $configProvider
      * @param OneclickInscriptionDataFactory $oneclickInscriptionDataFactory
      * @param WebpayOrderDataFactory $webpayOrderDataFactory
+     * @param ManagerInterface $messageManager
      */
     public function __construct(
         Context $context,

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -117,8 +117,8 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
             $this->log->logError($orderId);
             $this->log->logError($grandTotal);
 
-            $buyOrder = "100000".$orderId;
-            $childBuyOrder = "200000".$orderId;
+            $buyOrder = "100000" . $orderId;
+            $childBuyOrder = "200000" . $orderId;
 
             $details = [
                 [
@@ -152,7 +152,7 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
                 $this->checkoutSession->getQuote()->setIsActive(true)->save();
                 $this->cart->getQuote()->setIsActive(true)->save();
 
-                $orderLogs = '<h3>Pago autorizado exitosamente con '.$oneclickTitle.'</h3><br>'.json_encode($dataLog);
+                $orderLogs = '<h3>Pago autorizado exitosamente con ' . $oneclickTitle . '</h3><br>' . json_encode($dataLog);
                 $payment = $order->getPayment();
 
                 $payment->setLastTransId($response->details[0]->authorizationCode);
@@ -172,9 +172,7 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
                         'message' => $message
                     ]
                 );
-
                 return $resultJson->setData(['status' => 'success', 'response' => $response, '$webpayOrderData' => $webpayOrderData]);
-
             } else {
                 $webpayOrderData = $this->saveWebpayData(
                     $config['CHILD_COMMERCE_CODE'],
@@ -185,7 +183,7 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
                 );
 
                 $order->setStatus($orderStatusCanceled);
-                $message = '<h3>Error en Inscripción con Oneclick</h3><br>'.json_encode($response);
+                $message = '<h3>Error en Inscripción con Oneclick</h3><br>' . json_encode($response);
 
                 $order->addStatusToHistory($order->getStatus(), $message);
                 $order->cancel();
@@ -199,9 +197,8 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
                 // return $this->resultRedirectFactory->create()->setPath('checkout/cart');
                 return $resultJson->setData(['status' => 'error', 'response' => $response, 'flag' => 1]);
             }
-
         } catch (\Exception $e) {
-            $message = 'Error al crear transacción: '.$e->getMessage();
+            $message = 'Error al crear transacción: ' . $e->getMessage();
 
             $this->log->logError($message);
             $response = ['error' => $message];
@@ -216,7 +213,6 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
             $this->messageManager->addErrorMessage($e->getMessage());
             return $resultJson->setData(['status' => 'error', 'response' => $response, 'flag' => 2]);
         }
-
     }
 
     /**
@@ -233,7 +229,6 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
             $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
 
             return $objectManager->create('\Magento\Sales\Model\Order')->load($orderId);
-
         } catch (\Exception $e) {
             return null;
         }
@@ -327,10 +322,10 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
             • Order de Compra: <b>{$transactionResult->details[0]->buyOrder}</b>
         </div>
         <div>
-            • Fecha de la Transacci&oacute;n: <b>".date('d-m-Y', strtotime($transactionResult->transactionDate)).'</b>
+            • Fecha de la Transacci&oacute;n: <b>" . date('d-m-Y', strtotime($transactionResult->transactionDate)) . '</b>
         </div>
         <div>
-            • Hora de la Transacci&oacute;n: <b>'.date('H:i:s', strtotime($transactionResult->transactionDate))."</b>
+            • Hora de la Transacci&oacute;n: <b>' . date('H:i:s', strtotime($transactionResult->transactionDate)) . "</b>
         </div>
         <div>
             • Tarjeta: <b>**** **** **** {$transactionResult->cardNumber}</b>
@@ -355,8 +350,8 @@ class AuthorizeOneclick extends \Magento\Framework\App\Action\Action
                 <b>Respuesta de la Transacci&oacute;n: </b>{$this->responseCodeArray[$transactionResult->details[0]->responseCode]}<br>
                 <b>Monto:</b> $ {$transactionResult->details[0]->amount}<br>
                 <b>Order de Compra: </b> {$transactionResult->details[0]->buyOrder}<br>
-                <b>Fecha de la Transacci&oacute;n: </b>".date('d-m-Y', strtotime($transactionResult->transactionDate)).'<br>
-                <b>Hora de la Transacci&oacute;n: </b>'.date('H:i:s', strtotime($transactionResult->transactionDate))."<br>
+                <b>Fecha de la Transacci&oacute;n: </b>" . date('d-m-Y', strtotime($transactionResult->transactionDate)) . '<br>
+                <b>Hora de la Transacci&oacute;n: </b>' . date('H:i:s', strtotime($transactionResult->transactionDate)) . "<br>
                 <b>Tarjeta: </b>**** **** **** {$transactionResult->cardNumber}<br>
             </p>";
 

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -37,14 +37,14 @@ class AuthorizeOneclick extends Action
         '-99' => 'La transacción ha sido rechazada porque se superó la cantidad máxima de pagos diarios.',
     ];
 
-    protected $cart;
-    protected $checkoutSession;
-    protected $resultJsonFactory;
-    protected $quoteManagement;
-    protected $storeManager;
-    protected $oneclickInscriptionDataFactory;
-    protected $log;
-    protected $webpayOrderDataFactory;
+    private $cart;
+    private $checkoutSession;
+    private $resultJsonFactory;
+    private $quoteManagement;
+    private $storeManager;
+    private $oneclickInscriptionDataFactory;
+    private $log;
+    private $webpayOrderDataFactory;
     private $messageManager;
 
     /**

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -14,6 +14,7 @@ use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Store\Model\StoreManagerInterface;
 use Transbank\Webpay\Model\Config\ConfigProvider;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Controller\ResultInterface;
 use Transbank\Webpay\Model\TransbankSdkWebpayRest;
 use Transbank\Webpay\Model\WebpayOrderDataFactory;

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -99,7 +99,9 @@ class AuthorizeOneclick extends Action
                 return $resultJson->setData(['status' => 'error', 'message' => 'Error autorizando transacción', 'flag' => 0]);
             }
 
-            list($username, $tbkUser) = $this->getOneclickInscriptionData($inscriptionId);
+            $inscription = $this->getOneclickInscriptionData($inscriptionId);
+            $username = $inscription->getUsername();
+            $tbkUser = $inscription->getTbkUser();
 
             $config = $this->configProvider->getPluginConfigOneclick();
 
@@ -249,14 +251,10 @@ class AuthorizeOneclick extends Action
      *
      * @return OneclickInscriptionData
      */
-    protected function getOneclickInscriptionData($inscriptionId)
+    protected function getOneclickInscriptionData($inscriptionId): OneclickInscriptionData
     {
         $oneclickInscriptionDataModel = $this->oneclickInscriptionDataFactory->create();
-        $oneclickInscriptionData = $oneclickInscriptionDataModel->load($inscriptionId, 'id');
-        $tbkUser = $oneclickInscriptionData->getTbkUser();
-        $username = $oneclickInscriptionData->getUsername();
-
-        return [$username, $tbkUser];
+        return $oneclickInscriptionDataModel->load($inscriptionId, 'id');
     }
 
     /**

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -46,7 +46,7 @@ class AuthorizeOneclick extends Action
     private $oneclickInscriptionDataFactory;
     private $log;
     private $webpayOrderDataFactory;
-    private $messageManager;
+    protected $messageManager;
 
     /**
      * AuthorizeOneclick constructor.

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -290,6 +290,7 @@ class AuthorizeOneclick extends Action
             'quote_id'        => $quote_id,
             'amount'          => $amount,
             'metadata'        => json_encode($authorizeResponse),
+            'environment'     => $this->oneclickConfig['ENVIRONMENT'],
         ]);
         $webpayOrderData->save();
 

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -43,6 +43,7 @@ class AuthorizeOneclick extends Action
     private $log;
     private $webpayOrderDataFactory;
     protected $messageManager;
+    private $oneclickConfig;
 
     /**
      * AuthorizeOneclick constructor.
@@ -76,6 +77,7 @@ class AuthorizeOneclick extends Action
         $this->oneclickInscriptionDataFactory = $oneclickInscriptionDataFactory;
         $this->webpayOrderDataFactory = $webpayOrderDataFactory;
         $this->log = new PluginLogger();
+        $this->oneclickConfig = $configProvider->getPluginConfigOneclick();
     }
 
     /**
@@ -103,8 +105,6 @@ class AuthorizeOneclick extends Action
             $username = $inscription->getUsername();
             $tbkUser = $inscription->getTbkUser();
 
-            $config = $this->configProvider->getPluginConfigOneclick();
-
             $this->checkoutSession->restoreQuote();
 
             $quote = $this->cart->getQuote();
@@ -119,11 +119,11 @@ class AuthorizeOneclick extends Action
 
             $quote->save();
 
-            $transbankSdkWebpay = new TransbankSdkWebpayRest($config);
+            $transbankSdkWebpay = new TransbankSdkWebpayRest($this->oneclickConfig);
 
             $this->log->logError(json_encode($order));
 
-            $this->log->logError($config['CHILD_COMMERCE_CODE']);
+            $this->log->logError($this->oneclickConfig['CHILD_COMMERCE_CODE']);
             $this->log->logError($orderId);
             $this->log->logError($grandTotal);
 
@@ -132,7 +132,7 @@ class AuthorizeOneclick extends Action
 
             $details = [
                 [
-                    "commerce_code" => $config['CHILD_COMMERCE_CODE'],
+                    "commerce_code" => $this->oneclickConfig['CHILD_COMMERCE_CODE'],
                     "buy_order" => $childBuyOrder,
                     "amount" => $grandTotal,
                     "installments_number" => 1
@@ -185,7 +185,7 @@ class AuthorizeOneclick extends Action
                 return $resultJson->setData(['status' => 'success', 'response' => $response, '$webpayOrderData' => $webpayOrderData]);
             } else {
                 $webpayOrderData = $this->saveWebpayData(
-                    $config['CHILD_COMMERCE_CODE'],
+                    $this->oneclickConfig['CHILD_COMMERCE_CODE'],
                     $grandTotal,
                     OneclickInscriptionData::PAYMENT_STATUS_FAILED,
                     $orderId,

--- a/Model/Oneclick.php
+++ b/Model/Oneclick.php
@@ -5,6 +5,7 @@ namespace Transbank\Webpay\Model;
 class Oneclick extends \Magento\Payment\Model\Method\AbstractMethod
 {
     const CODE = 'transbank_oneclick';
+    const PRODUCT_NAME = 'webpay_oneclick';
 
     /**
      * Payment code.


### PR DESCRIPTION
This PR add mall commerce code, environment and product in transaction table.

## Test

### Database record
<img width="1001" alt="image" src="https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/58c3a985-c133-4583-a732-c975bd44f73b">
<img width="553" alt="image" src="https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/ff961cfa-7e85-4f97-ab77-f2ecdc544f6e">

### Oneclick Ok
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/e4ce03c0-415a-4242-bf43-11235e400cab)

### Install Ok
<img width="929" alt="image" src="https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/08bd28ba-8455-4374-9799-4b07917b34f0">

