### PR TITLE
fix: validate transaction status first

### DIFF
--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -303,6 +303,14 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         $order->save();
     }
 
+    private function checkTransactionIsAlreadyProcessed($token): bool
+    {
+        $webpayOrderData = $this->getWebpayOrderData($token);
+        $status = $webpayOrderData->getPaymentStatus();
+
+        return $status != WebpayOrderData::PAYMENT_STATUS_WATING;
+    }
+
     protected function getOrder($orderId): Order
     {
         $order = ObjectManagerHelper::get(Order::class);

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -22,6 +22,12 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     const WEBPAY_FLOW_ABORTED = 'aborted';
     const WEBPAY_FLOW_ERROR = 'error';
 
+    const WEBPAY_FAILED_FLOW_MESSAGE = 'Tu transacción no pudo ser autorizada. Ningún cobro fue realizado.';
+    const WEBPAY_CANCELED_BY_USER_FLOW_MESSAGE = 'Orden cancelada por el usuario.';
+    const WEBPAY_TIMEOUT_FLOW_MESSAGE = 'Orden cancelada por inactividad del usuario en el formulario de pago.';
+    const WEBPAY_ERROR_FLOW_MESSAGE = 'Orden cancelada por un error en el formulario de pago';
+    const WEBPAY_EXCEPTION_FLOW_MESSAGE = 'No se pudo procesar el pago.';
+
     protected $configProvider;
     protected $quoteRepository;
     protected $cart;
@@ -159,7 +165,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     {
         $this->log->logInfo('Procesando transacción por flujo timeout => Orden de compra: ' . $buyOrder);
 
-        $message = 'Orden cancelada por inactividad del usuario en el formulario de pago';
+        $message = self::WEBPAY_TIMEOUT_FLOW_MESSAGE;
 
         $webpayOrderData = $this->getWebpayOrderDataByBuyOrder($buyOrder);
         $token = $webpayOrderData->getToken();
@@ -171,7 +177,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     {
         $this->log->logInfo('Procesando transacción por flujo de pago abortado => Token: ' . $token);
 
-        $message = 'Orden cancelada por el usuario';
+        $message = self::WEBPAY_CANCELED_BY_USER_FLOW_MESSAGE;
 
         return $this->handleAbortedTransaction($token, $message, WebpayOrderData::PAYMENT_STATUS_CANCELED_BY_USER);
     }
@@ -180,7 +186,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     {
         $this->log->logInfo('Procesando transacción por flujo de error en formulario de pago => Token: ' . $token);
 
-        $message = 'Orden cancelada por un error en el formulario de pago';
+        $message = self::WEBPAY_ERROR_FLOW_MESSAGE;
 
         return $this->handleAbortedTransaction($token, $message, WebpayOrderData::PAYMENT_STATUS_ERROR);
     }
@@ -226,7 +232,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         $token = $webpayOrderData->getToken();
         $this->log->logInfo('Transacción rechazada por Transbank, cancelando orden => token: ' . $token);
 
-        $message = 'Tu transacción no pudo ser autorizada. Ningún cobro fue realizado.';
+        $message = self::WEBPAY_FAILED_FLOW_MESSAGE;
 
         $webpayOrderData->setPaymentStatus(WebpayOrderData::PAYMENT_STATUS_FAILED);
         $webpayOrderData->save();
@@ -261,7 +267,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
 
     private function handleException(Exception $exception)
     {
-        $message = 'No se pudo procesar el pago.';
+        $message = self::WEBPAY_EXCEPTION_FLOW_MESSAGE;
 
         $this->log->logError('Error al procesar el pago: ');
         $this->log->logError($exception->getMessage());

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -66,6 +66,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
             $requestMethod = $_SERVER['REQUEST_METHOD'];
             $request = $requestMethod === 'POST' ? $_POST : $_GET;
 
+            $this->log->logInfo('Procesando retorno desde formulario de Webpay.');
             $this->log->logInfo('Request: method -> ' . $requestMethod);
             $this->log->logInfo('Request: payload -> ' . json_encode($request));
 

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -144,6 +144,10 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     {
         $this->log->logInfo('Procesando transacción por flujo Normal => token: ' . $token);
 
+        if ($this->checkTransactionIsAlreadyProcessed($token)) {
+            return $this->handleTransactionAlreadyProcessed($token);
+        }
+
         $config = $this->configProvider->getPluginConfig();
         $webpayOrderData = $this->getWebpayOrderData($token);
         $orderId = $webpayOrderData->getOrderId();
@@ -170,12 +174,20 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         $webpayOrderData = $this->getWebpayOrderDataByBuyOrder($buyOrder);
         $token = $webpayOrderData->getToken();
 
+        if ($this->checkTransactionIsAlreadyProcessed($token)) {
+            return $this->handleTransactionAlreadyProcessed($token);
+        }
+
         return $this->handleAbortedTransaction($token, $message, WebpayOrderData::PAYMENT_STATUS_TIMEOUT);
     }
 
     private function handleFlowAborted(string $token)
     {
         $this->log->logInfo('Procesando transacción por flujo de pago abortado => Token: ' . $token);
+
+        if ($this->checkTransactionIsAlreadyProcessed($token)) {
+            return $this->handleTransactionAlreadyProcessed($token);
+        }
 
         $message = self::WEBPAY_CANCELED_BY_USER_FLOW_MESSAGE;
 
@@ -185,6 +197,10 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     private function handleFlowError(string $token)
     {
         $this->log->logInfo('Procesando transacción por flujo de error en formulario de pago => Token: ' . $token);
+
+        if ($this->checkTransactionIsAlreadyProcessed($token)) {
+            return $this->handleTransactionAlreadyProcessed($token);
+        }
 
         $message = self::WEBPAY_ERROR_FLOW_MESSAGE;
 


### PR DESCRIPTION
This PR add protections against double confirmations from the Transbank API.

## Tests

### Double commit
<img width="1700" alt="image" src="https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/22e7333a-2fb7-48c2-866f-aafbe8bb09b7">

![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/bbd7633f-c468-4bfb-9778-3f8add580e2f)

