### PR TITLE
fix: send mail when order is approved

### DIFF
--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -21,6 +21,7 @@ use Magento\Sales\Model\Order\Payment\Transaction;
 use Transbank\Webpay\Model\OneclickInscriptionData;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
 use Transbank\Webpay\Model\OneclickInscriptionDataFactory;
 
 
@@ -38,6 +39,7 @@ class AuthorizeOneclick extends Action
     private $log;
     private $webpayOrderDataFactory;
     private $resultPageFactory;
+    protected $eventManager;
     protected $messageManager;
     private $oneclickConfig;
 
@@ -60,6 +62,7 @@ class AuthorizeOneclick extends Action
         JsonFactory $resultJsonFactory,
         PageFactory $resultPageFactory,
         ConfigProvider $configProvider,
+        EventManagerInterface $eventManager,
         OneclickInscriptionDataFactory $oneclickInscriptionDataFactory,
         WebpayOrderDataFactory $webpayOrderDataFactory,
         ManagerInterface $messageManager
@@ -74,6 +77,7 @@ class AuthorizeOneclick extends Action
         $this->oneclickInscriptionDataFactory = $oneclickInscriptionDataFactory;
         $this->webpayOrderDataFactory = $webpayOrderDataFactory;
         $this->resultPageFactory = $resultPageFactory;
+        $this->eventManager = $eventManager;
         $this->log = new PluginLogger();
         $this->oneclickConfig = $configProvider->getPluginConfigOneclick();
     }
@@ -166,6 +170,11 @@ class AuthorizeOneclick extends Action
                 $order->save();
 
                 $this->checkoutSession->getQuote()->setIsActive(false)->save();
+
+                $this->eventManager->dispatch(
+                    'checkout_onepage_controller_success_action',
+                    ['order' => $order]
+                );
 
                 $formattedResponse = TbkResponseHelper::getOneclickFormattedResponse($response);
 

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -156,6 +156,10 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         $transbankSdkWebpay = new TransbankSdkWebpayRest($config);
         $commitResponse = $transbankSdkWebpay->commitTransaction($token);
 
+        if (is_array($commitResponse) && isset($commitResponse['error'])) {
+            $this->handleFlowError($token);
+        }
+
         $webpayOrderData->setMetadata(json_encode($commitResponse));
 
         if ($commitResponse->isApproved()) {

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -35,6 +35,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     protected $resultJsonFactory;
     protected $resultRawFactory;
     protected $resultPageFactory;
+    protected $eventManager;
     protected $webpayOrderDataFactory;
     protected $log;
 
@@ -46,6 +47,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
         \Magento\Framework\Controller\Result\RawFactory $resultRawFactory,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
+        \Magento\Framework\Event\ManagerInterface $eventManager,
         \Transbank\Webpay\Model\Config\ConfigProvider $configProvider,
         \Transbank\Webpay\Model\WebpayOrderDataFactory $webpayOrderDataFactory
     ) {
@@ -57,6 +59,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         $this->resultJsonFactory = $resultJsonFactory;
         $this->resultRawFactory = $resultRawFactory;
         $this->resultPageFactory = $resultPageFactory;
+        $this->eventManager = $eventManager;
         $this->messageManager = $context->getMessageManager();
         $this->configProvider = $configProvider;
         $this->webpayOrderDataFactory = $webpayOrderDataFactory;
@@ -238,6 +241,11 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         $order->save();
 
         $this->log->logInfo('Orden aprobada => Token: ' . $token);
+
+        $this->eventManager->dispatch(
+            'checkout_onepage_controller_success_action',
+            ['order' => $order]
+        );
 
         $responseData = TbkResponseHelper::getWebpayFormattedResponse($commitResponse);
 


### PR DESCRIPTION
This PR fixes the email sending flow when the behavior is not the default one.

## Test

### Transaction Ok
![image](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/f284ff80-d590-4f90-a932-8c125d3e18d4)

### Order mail
<img width="770" alt="image" src="https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/assets/36648048/3afc98dd-1c8c-482c-821a-3ea03d4be4c9">
