### PR TITLE
refactor: add validation for double authorization

### DIFF
--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -175,20 +175,14 @@ class AuthorizeOneclick extends Action
                 $order->addStatusToHistory($order->getStatus(), $orderLogs);
                 $order->save();
 
-                $this->checkoutSession->getQuote()->setIsActive(false)->save();
-
                 $this->eventManager->dispatch(
                     'checkout_onepage_controller_success_action',
                     ['order' => $order]
                 );
 
-                $formattedResponse = TbkResponseHelper::getOneclickFormattedResponse($response);
+                $responseData = TbkResponseHelper::getOneclickFormattedResponse($response);
 
-                $resultPage = $this->resultPageFactory->create();
-                $resultPage->addHandle('transbank_checkout_success');
-                $block = $resultPage->getLayout()->getBlock('transbank_success');
-                $block->setResponse($formattedResponse);
-                return $resultPage;
+                return $this->redirectToSuccess($responseData);
             } else {
                 return $this->handleUnauthorizedTransaction($order, $response, $grandTotal);
             }
@@ -235,6 +229,17 @@ class AuthorizeOneclick extends Action
         }
 
         return $this->redirectWithErrorMessage($message);
+    }
+
+    private function redirectToSuccess(array $responseData)
+    {
+        $this->checkoutSession->getQuote()->setIsActive(false)->save();
+
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->addHandle('transbank_checkout_success');
+        $block = $resultPage->getLayout()->getBlock('transbank_success');
+        $block->setResponse($responseData);
+        return $resultPage;
     }
 
     private function redirectWithErrorMessage(string $message)

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -9,9 +9,9 @@ use Magento\Checkout\Model\Session;
 use Transbank\Webpay\Model\Oneclick;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
-use Magento\Framework\App\ObjectManager;
 use Transbank\Webpay\Helper\PluginLogger;
 use Transbank\Webpay\Helper\TbkResponseHelper;
+use Transbank\Webpay\Helper\ObjectManagerHelper;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Json;
 use Transbank\Webpay\Model\Config\ConfigProvider;
@@ -129,7 +129,7 @@ class AuthorizeOneclick extends Action
         $quote->collectTotals();
         $quote->save();
 
-        $order = $this->getOrder();
+        $order = $this->getOrder($this->checkoutSession->getLastOrderId());
         $orderId = $order->getId();
         $grandTotal = round($order->getGrandTotal());
 
@@ -270,22 +270,16 @@ class AuthorizeOneclick extends Action
     }
 
     /**
-     * @return |null
+     * @return Order
      */
-    private function getOrder()
+    private function getOrder($orderId): Order
     {
-        try {
-            $orderId = $this->checkoutSession->getLastOrderId();
-            if ($orderId == null) {
-                return null;
-            }
+        /**
+         * @var Order
+         */
+        $order = ObjectManagerHelper::get(Order::class);
 
-            $objectManager = ObjectManager::getInstance();
-
-            return $objectManager->create('\Magento\Sales\Model\Order')->load($orderId);
-        } catch (\Exception $e) {
-            return null;
-        }
+        return $order->load($orderId);
     }
 
     /**

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -201,9 +201,7 @@ class AuthorizeOneclick extends Action
                 $this->quoteHelper->processQuoteForCancelOrder($order->getQuoteId());
 
                 $message = 'Tu transacción no pudo ser autorizada. Ningún cobro fue realizado.';
-                $this->messageManager->addErrorMessage(__($message));
-
-                return $this->resultRedirectFactory->create()->setPath('checkout/cart');
+                return $this->redirectWithErrorMessage($message);
             }
         } catch (\Exception $e) {
             $message = 'Error al crear transacción: ' . $e->getMessage();
@@ -216,10 +214,15 @@ class AuthorizeOneclick extends Action
                 $this->quoteHelper->processQuoteForCancelOrder($order->getQuoteId());
             }
 
-            $this->messageManager->addErrorMessage($e->getMessage());
-            return $this->resultRedirectFactory->create()->setPath('checkout/cart');
+            return $this->redirectWithErrorMessage($e->getMessage());
         }
     }
+    private function redirectWithErrorMessage(string $message)
+    {
+        $this->messageManager->addErrorMessage(__($message));
+        return $this->resultRedirectFactory->create()->setPath('checkout/cart');
+    }
+
     private function cancelOrder(Order $order, string $message)
     {
         $orderStatusCanceled = $this->configProvider->getOneclickOrderErrorStatus();

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -39,6 +39,7 @@ use Transbank\Webpay\Model\WebpayOrderData;
 class AuthorizeOneclick extends Action
 {
     const ONECLICK_EXCEPTION_FLOW_MESSAGE = 'No se pudo procesar el pago.';
+    const AUTHORIZED_RESPONSE_CODE = 0;
     protected $configProvider;
 
     private $cart;
@@ -167,7 +168,10 @@ class AuthorizeOneclick extends Action
 
         $authorizeResponse = $transbankSdkWebpay->authorizeTransaction($username, $tbkUser, $buyOrder, $details);
 
-        if (isset($authorizeResponse->details) && $authorizeResponse->details[0]->responseCode == 0) {
+        if (
+            isset($authorizeResponse->details) &&
+            $authorizeResponse->details[0]->responseCode == self::AUTHORIZED_RESPONSE_CODE
+        ) {
             return $this->handleAuthorizedTransaction($order, $authorizeResponse, $grandTotal);
         } else {
             return $this->handleUnauthorizedTransaction($order, $authorizeResponse, $grandTotal);

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Transbank\Webpay\Controller\Transaction;
+
 use Exception;
 use Magento\Checkout\Model\Cart;
 use Magento\Checkout\Model\Session;
@@ -144,7 +145,7 @@ class AuthorizeOneclick extends Action
 
             if (isset($response->details) && $response->details[0]->responseCode == 0) {
 
-                $webpayOrderData = $this->saveWebpayData(
+                $webpayOrderData = $this->saveOneclickData(
                     $response,
                     $grandTotal,
                     OneclickInscriptionData::PAYMENT_STATUS_SUCCESS,
@@ -188,7 +189,7 @@ class AuthorizeOneclick extends Action
                 $block->setResponse($formattedResponse);
                 return $resultPage;
             } else {
-                $webpayOrderData = $this->saveWebpayData(
+                $webpayOrderData = $this->saveOneclickData(
                     $response,
                     $grandTotal,
                     OneclickInscriptionData::PAYMENT_STATUS_FAILED,
@@ -294,7 +295,7 @@ class AuthorizeOneclick extends Action
      *
      * @return WebpayOrderData
      */
-    protected function saveWebpayData($authorizeResponse, $amount, $payment_status, $order_id, $quote_id)
+    protected function saveOneclickData($authorizeResponse, $amount, $payment_status, $order_id, $quote_id)
     {
         $webpayOrderData = $this->webpayOrderDataFactory->create();
         $webpayOrderData->setData([

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -23,6 +23,7 @@ use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\View\Result\PageFactory;
 use Transbank\Webpay\Helper\QuoteHelper;
 use Transbank\Webpay\Model\OneclickInscriptionDataFactory;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
 
 
 /**

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -141,7 +141,7 @@ class AuthorizeOneclick extends Action
                 return $resultJson->setData(['status' => 'error', 'message' => 'Error autorizando transacción', 'flag' => 0]);
             }
 
-            setcookie($cookieIdForBuyOrder, 'true', time() + 100, '/');
+            setcookie($cookieIdForBuyOrder, 'true', time() + 100, '/', '', true, true);
 
             $quote->getPayment()->importData(['method' => Oneclick::CODE]);
             $quote->collectTotals();
@@ -232,13 +232,13 @@ class AuthorizeOneclick extends Action
                 $message = 'Tu transacción no pudo ser autorizada. Ningún cobro fue realizado.';
                 $this->messageManager->addErrorMessage(__($message));
 
-                setcookie($cookieIdForBuyOrder, '', time() - 1000, '/');
+                setcookie($cookieIdForBuyOrder, '', time() - 1000, '/', true, true);
                 return $this->resultRedirectFactory->create()->setPath('checkout/cart');
             }
         } catch (\Exception $e) {
             $message = 'Error al crear transacción: ' . $e->getMessage();
 
-            setcookie($cookieIdForBuyOrder, '', time() - 1000, '/');
+            setcookie($cookieIdForBuyOrder, '', time() - 1000, '/', true, true);
 
             $this->log->logError($message);
             $response = ['error' => $message];

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -274,17 +274,17 @@ class AuthorizeOneclick extends Action
     private function handleTransactionAlreadyProcessed(int $orderId, int $quoteId)
     {
         $webpayOrderData = $this->getWebpayOrderDataByOrderIdAndQuoteId($orderId, $quoteId);
-            $status = $webpayOrderData->getPaymentStatus();
+        $status = $webpayOrderData->getPaymentStatus();
 
-            if ($status == WebpayOrderData::PAYMENT_STATUS_SUCCESS) {
-                $metadata = $webpayOrderData->getMetadata();
-                $response = json_decode($metadata);
-                $formattedResponse = TbkResponseHelper::getOneclickFormattedResponse($response);
+        if ($status == WebpayOrderData::PAYMENT_STATUS_SUCCESS) {
+            $metadata = $webpayOrderData->getMetadata();
+            $response = json_decode($metadata);
+            $formattedResponse = TbkResponseHelper::getOneclickFormattedResponse($response);
 
-                return $this->redirectToSuccess($formattedResponse);
-            }
+            return $this->redirectToSuccess($formattedResponse);
+        }
 
-            return $this->redirectWithErrorMessage("La orden ya fue procesada.");
+        return $this->redirectWithErrorMessage("La orden ya fue procesada.");
     }
 
     /**

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -98,9 +98,9 @@ class AuthorizeOneclick extends Action
     }
 
     /**
-     * @throws \Exception
+     * This method handle the controller request.
      *
-     * @return ResponseInterface|Json|ResultInterface
+     * @return Page|Redirect The result of handling the request.
      */
     public function execute()
     {
@@ -124,6 +124,13 @@ class AuthorizeOneclick extends Action
         }
     }
 
+    /**
+     * This method handle Oneclick Request
+     *
+     * @param int $inscriptionId The Id for the inscription.
+     *
+     * @return Page|Redirect The result of handling Oneclick the request.
+     */
     private function handleOneclickRequest(int $inscriptionId)
     {
         $inscription = $this->getOneclickInscriptionData($inscriptionId);
@@ -167,6 +174,15 @@ class AuthorizeOneclick extends Action
         }
     }
 
+    /**
+     * This method handle de authorized transaction flow.
+     *
+     * @param Order                            $order             The Magento order.
+     * @param MallTransactionAuthorizeResponse $authorizeResponse The Oneclick authorization response.
+     * @param float                            $totalAmount       The total amount of the order.
+     *
+     * @return Page The success result page.
+     */
     private function handleAuthorizedTransaction(
         Order $order,
         MallTransactionAuthorizeResponse $authorizeResponse,
@@ -215,6 +231,16 @@ class AuthorizeOneclick extends Action
         return $this->redirectToSuccess($responseData);
     }
 
+
+    /**
+     * This method handle de unauthorized transaction flow.
+     *
+     * @param Order                            $order             The Magento order.
+     * @param MallTransactionAuthorizeResponse $authorizeResponse The Oneclick authorization response.
+     * @param float                            $totalAmount       The total amount of the order.
+     *
+     * @return Redirect Redirect to cart page.
+     */
     private function handleUnauthorizedTransaction(
         Order $order,
         MallTransactionAuthorizeResponse $authorizeResponse,
@@ -237,6 +263,14 @@ class AuthorizeOneclick extends Action
         return $this->redirectWithErrorMessage($message);
     }
 
+    /**
+     * This method handle the flow for orders already processed.
+     *
+     * @param int $orderId The order id.
+     * @param int $quoteId The quote id.
+     *
+     * @return Page|Redirect The result of handling Oneclick the request.
+     */
     private function handleTransactionAlreadyProcessed(int $orderId, int $quoteId)
     {
         $webpayOrderData = $this->getWebpayOrderDataByOrderIdAndQuoteId($orderId, $quoteId);
@@ -253,6 +287,13 @@ class AuthorizeOneclick extends Action
             return $this->redirectWithErrorMessage("La orden ya fue procesada.");
     }
 
+    /**
+     * This method will handle the flow when an exception is thrown.
+     *
+     * @param Exception $exception The exception object.
+     *
+     * @return Redirect Redirect to cart page.
+     */
     private function handleException(Exception $exception): Redirect
     {
         $message = self::ONECLICK_EXCEPTION_FLOW_MESSAGE;
@@ -271,6 +312,13 @@ class AuthorizeOneclick extends Action
         return $this->redirectWithErrorMessage($message);
     }
 
+    /**
+     * This method show the success result page.
+     *
+     * @param array $responseData The formatted response.
+     *
+     * @return Page The success result page.
+     */
     private function redirectToSuccess(array $responseData): Page
     {
         $resultPage = $this->resultPageFactory->create();
@@ -280,12 +328,28 @@ class AuthorizeOneclick extends Action
         return $resultPage;
     }
 
+    /**
+     * This method redirect to the cart page.
+     *
+     * @param string $message The error message to show in the page.
+     *
+     * @return Redirect Redirect to cart page.
+     */
     private function redirectWithErrorMessage(string $message): Redirect
     {
         $this->messageManager->addErrorMessage(__($message));
         return $this->resultRedirectFactory->create()->setPath('checkout/cart');
     }
 
+
+    /**
+     * This method cancels the order and updates its status.
+     *
+     * @param Order $order The Magento order.
+     * @param string $message The message to show in order resume.
+     *
+     * @return void
+     */
     private function cancelOrder(Order $order, string $message): void
     {
         $orderStatusCanceled = $this->configProvider->getOneclickOrderErrorStatus();
@@ -295,6 +359,14 @@ class AuthorizeOneclick extends Action
         $order->save();
     }
 
+    /**
+     * This method check if the order already process.
+     *
+     * @param int $orderId The order id.
+     * @param int $quoteId The quote id.
+     *
+     * @return bool True if the order is already processed, false if it is not processed.
+     */
     private function checkTransactionIsAlreadyProcessed(int $orderId, int $quoteId): bool
     {
         $webpayOrderData = $this->getWebpayOrderDataByOrderIdAndQuoteId($orderId, $quoteId);
@@ -306,7 +378,11 @@ class AuthorizeOneclick extends Action
     }
 
     /**
-     * @return Order
+     * This method return the order object based on the id.
+     *
+     * @param int $orderId The order id.
+     *
+     * @return Order The Magento order.
      */
     private function getOrder(int $orderId): Order
     {
@@ -318,17 +394,24 @@ class AuthorizeOneclick extends Action
         return $order->load($orderId);
     }
 
+    /**
+     * This method return the WebpayOrderData base on the order id and quote id.
+     *
+     * @param int $orderId The order id.
+     * @param int $quoteId The quite id.
+     *
+     * @return WebpayOrderData The Webpay order data object.
+     */
     private function getWebpayOrderDataByOrderIdAndQuoteId(int $orderId, int $quoteId): WebpayOrderData
     {
         return $this->webpayOrderDataRepository->getByOrderIdAndQuoteId($orderId, $quoteId);
     }
 
     /**
-     * @param $inscriptionId
+     * This method return the OneclickInscriptionData based on the id.
+     * @param $inscriptionId The OneclickInscriptionData id.
      *
-     * @throws \Exception
-     *
-     * @return OneclickInscriptionData
+     * @return OneclickInscriptionData The Oneclick inscription data object.
      */
     protected function getOneclickInscriptionData(int $inscriptionId): OneclickInscriptionData
     {
@@ -337,14 +420,13 @@ class AuthorizeOneclick extends Action
     }
 
     /**
-     * @param $buyOrder
-     * @param $childBuyOrder
-     * @param $commerceCode
-     * @param $payment_status
-     * @param $order_id
-     * @param $quote_id
+     * This method update the WebpayOrderData.
      *
-     * @throws \Exception
+     * @param MallTransactionAuthorizeResponse $authorizeResponse The authorization response.
+     * @param float $amount The amount of the order.
+     * @param string $payment_status The payment status.
+     * @param int $order_id The order id.
+     * @param int $quote_id The quote id.
      *
      * @return WebpayOrderData
      */

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -96,6 +96,8 @@ class AuthorizeOneclick extends Action
         $orderStatusCanceled = $this->configProvider->getOneclickOrderErrorStatus();
         $orderStatusSuccess = $this->configProvider->getOneclickOrderSuccessStatus();
         $oneclickTitle = $this->configProvider->getOneclickTitle();
+        $cookieName = 'AUTHORIZE_TRANSACTION-BUY-ORDER:';
+        $cookieIdForBuyOrder = "";
 
         try {
             $resultJson = $this->resultJsonFactory->create();
@@ -113,14 +115,37 @@ class AuthorizeOneclick extends Action
             $this->checkoutSession->restoreQuote();
 
             $quote = $this->cart->getQuote();
-
-            $quote->getPayment()->importData(['method' => Oneclick::CODE]);
-            $quote->collectTotals();
             $order = $this->getOrder();
-            $grandTotal = round($order->getGrandTotal());
 
             $quoteId = $quote->getId();
             $orderId = $order->getId();
+            $orderStatus = $order->getStatus();
+
+            if ($orderStatus == $orderStatusCanceled) {
+                $this->log->logInfo('Cancelando flujo ya que la transaccion ya esta cancelada');
+                $this->messageManager->addErrorMessage(__('Error al autorizar la transacción'));
+                return $resultJson->setData(['status' => 'error', 'message' => 'Esta transacción ha sido cancelada', 'flag' => 0]);
+            }
+
+            if ($orderStatus == $orderStatusSuccess) {
+                $this->log->logInfo('Cancelando flujo ya que la transaccion ya esta autorizada');
+                $this->messageManager->addErrorMessage(__('Error al autorizar la transacción'));
+                return $resultJson->setData(['status' => 'error', 'message' => 'Esta transacción ya ha sido autorizada', 'flag' => 0]);
+            }
+
+            $cookieIdForBuyOrder = $cookieName . $orderId;
+
+            if (isset($_COOKIE[$cookieIdForBuyOrder])) {
+                $this->log->logInfo('Cancelando flujo ya que la transaccion ya esta en proceso');
+                $this->messageManager->addErrorMessage(__('Error al autorizar la transacción'));
+                return $resultJson->setData(['status' => 'error', 'message' => 'Error autorizando transacción', 'flag' => 0]);
+            }
+
+            setcookie($cookieIdForBuyOrder, 'true', time() + 100, '/');
+
+            $quote->getPayment()->importData(['method' => Oneclick::CODE]);
+            $quote->collectTotals();
+            $grandTotal = round($order->getGrandTotal());
 
             $quote->save();
 
@@ -207,10 +232,13 @@ class AuthorizeOneclick extends Action
                 $message = 'Tu transacción no pudo ser autorizada. Ningún cobro fue realizado.';
                 $this->messageManager->addErrorMessage(__($message));
 
+                setcookie($cookieIdForBuyOrder, '', time() - 1000, '/');
                 return $this->resultRedirectFactory->create()->setPath('checkout/cart');
             }
         } catch (\Exception $e) {
             $message = 'Error al crear transacción: ' . $e->getMessage();
+
+            setcookie($cookieIdForBuyOrder, '', time() - 1000, '/');
 
             $this->log->logError($message);
             $response = ['error' => $message];

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -232,13 +232,13 @@ class AuthorizeOneclick extends Action
                 $message = 'Tu transacción no pudo ser autorizada. Ningún cobro fue realizado.';
                 $this->messageManager->addErrorMessage(__($message));
 
-                setcookie($cookieIdForBuyOrder, '', time() - 1000, '/', true, true);
+                setcookie($cookieIdForBuyOrder, '', time() - 1000, '/', true, true, true);
                 return $this->resultRedirectFactory->create()->setPath('checkout/cart');
             }
         } catch (\Exception $e) {
             $message = 'Error al crear transacción: ' . $e->getMessage();
 
-            setcookie($cookieIdForBuyOrder, '', time() - 1000, '/', true, true);
+            setcookie($cookieIdForBuyOrder, '', time() - 1000, '/', true, true, true);
 
             $this->log->logError($message);
             $response = ['error' => $message];

--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -302,14 +302,6 @@ class AuthorizeOneclick extends Action
     }
 
     /**
-     * @return string
-     */
-    protected function getOrderId()
-    {
-        return $this->checkoutSession->getLastRealOrderId();
-    }
-
-    /**
      * @param $buyOrder
      * @param $childBuyOrder
      * @param $commerceCode

--- a/Exceptions/InvalidRequestException.php
+++ b/Exceptions/InvalidRequestException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Transbank\Webpay\Exceptions;
+
+class InvalidRequestException extends \Exception
+{
+
+}

--- a/Model/ResourceModel/WebpayOrderData/Collection.php
+++ b/Model/ResourceModel/WebpayOrderData/Collection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Transbank\Webpay\Model\ResourceModel\WebpayOrderData;
+
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+/**
+ * Class Collection
+ * Collection for WebpayOrderData model
+ */
+class Collection extends AbstractCollection
+{
+    /**
+     * Initialize collection
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init(
+            'Transbank\Webpay\Model\WebpayOrderData',
+            'Transbank\Webpay\Model\ResourceModel\WebpayOrderData'
+        );
+    }
+}

--- a/Model/ResourceModel/WebpayOrderData/CollectionFactory.php
+++ b/Model/ResourceModel/WebpayOrderData/CollectionFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Transbank\Webpay\Model\ResourceModel\WebpayOrderData;
+
+use Magento\Framework\ObjectManagerInterface;
+
+class CollectionFactory
+{
+    protected $objectManager;
+
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    public function create(array $data = [])
+    {
+        return $this->objectManager->create(Collection::class, $data);
+    }
+}

--- a/Model/TransbankSdkWebpayRest.php
+++ b/Model/TransbankSdkWebpayRest.php
@@ -56,14 +56,13 @@ class TransbankSdkWebpayRest
             $this->mallInscription = new Oneclick\MallInscription();
             $this->mallTransaction = new Oneclick\MallTransaction();
 
-            $this->log->logInfo('Environment: '.json_encode($environment));
+            $this->log->logInfo('Environment: ' . json_encode($environment));
 
             if ($environment != 'TEST') {
                 $this->transaction->configureForProduction($config['COMMERCE_CODE'], $config['API_KEY']);
                 $this->mallInscription->configureForProduction($config['COMMERCE_CODE'], $config['API_KEY']);
                 $this->mallTransaction->configureForProduction($config['COMMERCE_CODE'], $config['API_KEY']);
             }
-
         }
     }
 
@@ -84,19 +83,19 @@ class TransbankSdkWebpayRest
         try {
             $txDate = date('d-m-Y');
             $txTime = date('H:i:s');
-            $this->log->logInfo('createTransaction - amount: '.$amount.', sessionId: '.$sessionId.
-                ', buyOrder: '.$buyOrder.', txDate: '.$txDate.', txTime: '.$txTime);
+            $this->log->logInfo('createTransaction - amount: ' . $amount . ', sessionId: ' . $sessionId .
+                ', buyOrder: ' . $buyOrder . ', txDate: ' . $txDate . ', txTime: ' . $txTime);
 
             $createResult = $this->transaction->create($buyOrder, $sessionId, $amount, $returnUrl);
 
-            $this->log->logInfo('createTransaction - createResult: '.json_encode($createResult));
+            $this->log->logInfo('createTransaction - createResult: ' . json_encode($createResult));
             if (isset($createResult) && isset($createResult->url) && isset($createResult->token)) {
                 $result = [
                     'url'      => $createResult->url,
                     'token_ws' => $createResult->token,
                 ];
             } else {
-                throw new TransbankCreateException('No se ha creado la transacción para, amount: '.$amount.', sessionId: '.$sessionId.', buyOrder: '.$buyOrder);
+                throw new TransbankCreateException('No se ha creado la transacción para, amount: ' . $amount . ', sessionId: ' . $sessionId . ', buyOrder: ' . $buyOrder);
             }
         } catch (TransactionCreateException $e) {
             $result = [
@@ -125,7 +124,7 @@ class TransbankSdkWebpayRest
 
             $transaction = $this->transaction->commit($tokenWs);
 
-            $this->log->logInfo('commitTransaction: '.json_encode($transaction));
+            $this->log->logInfo('commitTransaction: ' . json_encode($transaction));
             return $transaction;
         } catch (TransactionCommitException $e) {
             $result = [
@@ -152,19 +151,19 @@ class TransbankSdkWebpayRest
         $result = [];
 
         try {
-            $this->log->logInfo('initInscription - Username: '.$username.', email: '.$email.
-                ', responseUrl: '.$responseUrl);
+            $this->log->logInfo('initInscription - Username: ' . $username . ', email: ' . $email .
+                ', responseUrl: ' . $responseUrl);
 
             $initResult = $this->mallInscription->start($username, $email, $responseUrl);
 
-            $this->log->logInfo('createInscription - initResult: '.json_encode($initResult));
+            $this->log->logInfo('createInscription - initResult: ' . json_encode($initResult));
             if (isset($initResult) && isset($initResult->token) && isset($initResult->urlWebpay)) {
                 $result = [
                     'token'      => $initResult->token,
                     'urlWebpay' => $initResult->urlWebpay,
                 ];
             } else {
-                throw new TransbankCreateException('No se ha creado la inscripción para, username: '.$username.', email: '.$email.', responseUrl: '.$responseUrl);
+                throw new TransbankCreateException('No se ha creado la inscripción para, username: ' . $username . ', email: ' . $email . ', responseUrl: ' . $responseUrl);
             }
         } catch (InscriptionStartException $e) {
             $result = [
@@ -187,13 +186,13 @@ class TransbankSdkWebpayRest
     public function finishInscription($tbkToken)
     {
         try {
-            $this->log->logInfo('getInscriptonResult - tokenWs: '.$tbkToken);
+            $this->log->logInfo('getInscriptonResult - tokenWs: ' . $tbkToken);
             if ($tbkToken == null) {
                 throw new MissingArgumentException('El token tokenWs es requerido');
             }
 
             $inscription = $this->mallInscription->finish($tbkToken);
-            $this->log->logInfo('finishInscription: '.json_encode($inscription));
+            $this->log->logInfo('finishInscription: ' . json_encode($inscription));
 
             return $inscription;
         } catch (InscriptionFinishException $e) {
@@ -250,10 +249,9 @@ class TransbankSdkWebpayRest
             }
 
             $delInscription = $this->mallInscription->delete($tbkUser, $username);
-            $this->log->logInfo('deleteInscription: '.json_encode($delInscription));
+            $this->log->logInfo('deleteInscription: ' . json_encode($delInscription));
 
             return $delInscription;
-
         } catch (InscriptionFinishException $e) {
             $result = [
                 'error'  => 'Error al eliminar una inscripción',
@@ -280,10 +278,8 @@ class TransbankSdkWebpayRest
         string $childCommerceCode,
         string $childBuyOrder,
         int $amount
-        ): \Transbank\Webpay\Oneclick\Responses\MallTransactionRefundResponse
-    {
+    ): \Transbank\Webpay\Oneclick\Responses\MallTransactionRefundResponse {
         return $this->mallTransaction->refund($buyOrder, $childCommerceCode, $childBuyOrder, $amount);
-
     }
 
     /**
@@ -298,9 +294,7 @@ class TransbankSdkWebpayRest
     public function refundWebpayPlusTransaction(
         string $token,
         int $amount
-        ): \Transbank\Webpay\WebpayPlus\Responses\TransactionRefundResponse
-    {
+    ): \Transbank\Webpay\WebpayPlus\Responses\TransactionRefundResponse {
         return $this->transaction->refund($token, $amount);
-
     }
 }

--- a/Model/TransbankSdkWebpayRest.php
+++ b/Model/TransbankSdkWebpayRest.php
@@ -208,35 +208,30 @@ class TransbankSdkWebpayRest
     }
 
     /**
+     * This method authorize a Oneclick transaction.
+     *
      * @param $username
      * @param $tbkUser
      * @param $total
      *
      * @throws MissingArgumentException
      *
-     * @return array|MallTransactionAuthorizeResponse
+     * @return MallTransactionAuthorizeResponse
      */
-    public function authorizeTransaction($username, $tbkUser, $buyOrder, $details)
-    {
-        try {
-            if ($username == null || $tbkUser == null) {
-                throw new MissingArgumentException('El token tbkUser y el username son requerido');
-            }
-
-            $transaction = $this->mallTransaction->authorize($username, $tbkUser, $buyOrder, $details);
-            $this->log->logInfo('authorizeTransaction: '.json_encode($transaction));
-
-            return $transaction;
-
-        } catch (InscriptionFinishException $e) {
-            $result = [
-                'error'  => 'Error al autorizar la transacción',
-                'detail' => $e->getMessage(),
-            ];
-            $this->log->logError(json_encode($result));
+    public function authorizeTransaction(
+        string $username,
+        string $tbkUser,
+        string $buyOrder,
+        array $details
+    ): MallTransactionAuthorizeResponse {
+        if ($username == null || $tbkUser == null) {
+            throw new MissingArgumentException('El token tbkUser y el username son requerido');
         }
 
-        return $result;
+        $transaction = $this->mallTransaction->authorize($username, $tbkUser, $buyOrder, $details);
+        $this->log->logInfo('authorizeTransaction: ' . json_encode($transaction));
+
+        return $transaction;
     }
 
     /**

--- a/Model/TransbankSdkWebpayRest.php
+++ b/Model/TransbankSdkWebpayRest.php
@@ -12,6 +12,7 @@ use Transbank\Webpay\WebpayPlus\Exceptions\TransactionCreateException;
 use Transbank\Webpay\Oneclick;
 use Transbank\Webpay\Oneclick\Exceptions\InscriptionStartException;
 use Transbank\Webpay\Oneclick\Exceptions\InscriptionFinishException;
+use Transbank\Webpay\Oneclick\Responses\MallTransactionAuthorizeResponse;
 
 /**
  * Class TransbankSdkWebpayRest.
@@ -213,7 +214,7 @@ class TransbankSdkWebpayRest
      *
      * @throws MissingArgumentException
      *
-     * @return array
+     * @return array|MallTransactionAuthorizeResponse
      */
     public function authorizeTransaction($username, $tbkUser, $buyOrder, $details)
     {

--- a/Model/TransbankSdkWebpayRest.php
+++ b/Model/TransbankSdkWebpayRest.php
@@ -209,13 +209,14 @@ class TransbankSdkWebpayRest
     /**
      * This method authorize a Oneclick transaction.
      *
-     * @param $username
-     * @param $tbkUser
-     * @param $total
+     * @param string $username The username of the inscription.
+     * @param string $tbkUser  The tbk_user of the inscription.
+     * @param string $buyOrder The buy order.
+     * @param array $details  The transactions details.
      *
-     * @throws MissingArgumentException
+     * @throws MissingArgumentException Thrown when username or tbk_user is null.
      *
-     * @return MallTransactionAuthorizeResponse
+     * @return MallTransactionAuthorizeResponse The authorization response.
      */
     public function authorizeTransaction(
         string $username,

--- a/Model/TransbankSdkWebpayRest.php
+++ b/Model/TransbankSdkWebpayRest.php
@@ -224,7 +224,7 @@ class TransbankSdkWebpayRest
         array $details
     ): MallTransactionAuthorizeResponse {
         if ($username == null || $tbkUser == null) {
-            throw new MissingArgumentException('El token tbkUser y el username son requerido');
+            throw new MissingArgumentException('El token tbkUser y el username son requeridos');
         }
 
         $transaction = $this->mallTransaction->authorize($username, $tbkUser, $buyOrder, $details);

--- a/Model/WebpayOrderData.php
+++ b/Model/WebpayOrderData.php
@@ -13,6 +13,8 @@ class WebpayOrderData extends AbstractModel implements \Magento\Framework\DataOb
     const PAYMENT_STATUS_CANCELED_BY_USER = 'CANCELED_BY_USER';
     const PAYMENT_STATUS_ERROR = 'ERROR';
     const PAYMENT_STATUS_TIMEOUT = 'TIMEOUT';
+    const PAYMENT_STATUS_NULLIFIED = 'NULLIFIED';
+    const PAYMENT_STATUS_REVERSED = 'REVERSED';
 
     /**
      * @return void

--- a/Model/WebpayOrderData.php
+++ b/Model/WebpayOrderData.php
@@ -3,8 +3,9 @@
 namespace Transbank\Webpay\Model;
 
 use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\DataObject\IdentityInterface;
 
-class WebpayOrderData extends AbstractModel implements \Magento\Framework\DataObject\IdentityInterface
+class WebpayOrderData extends AbstractModel implements IdentityInterface
 {
     const CACHE_TAG = 'webpay_order_data';
     const PAYMENT_STATUS_WATING = 'WAITING';

--- a/Model/WebpayOrderDataFactory.php
+++ b/Model/WebpayOrderDataFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Transbank\Webpay\Model;
+
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * Class WebpayOrderDataFactory
+ * Factory for creating instances of WebpayOrderData
+ */
+class WebpayOrderDataFactory
+{
+    protected $objectManager;
+
+    /**
+     * Constructor
+     *
+     * @param ObjectManagerInterface $objectManager Object manager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Create a new instance of WebpayOrderData
+     *
+     * @param array $data Data to initialize the model
+     *
+     * @return WebpayOrderData
+     */
+    public function create(array $data = [])
+    {
+        return $this->objectManager->create(WebpayOrderData::class, $data);
+    }
+}

--- a/Model/WebpayOrderDataRepository.php
+++ b/Model/WebpayOrderDataRepository.php
@@ -36,7 +36,7 @@ class WebpayOrderDataRepository
      *
      * @return WebpayOrderData
      */
-    public function getByOrderIdAndQuoteId($orderId, $quoteId)
+    public function getByOrderIdAndQuoteId(int $orderId, int $quoteId): WebpayOrderData
     {
         $collection = $this->collectionFactory->create();
         $collection->addFieldToFilter('order_id', $orderId)

--- a/Model/WebpayOrderDataRepository.php
+++ b/Model/WebpayOrderDataRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Transbank\Webpay\Model;
+
+use Transbank\Webpay\Model\WebpayOrderDataFactory;
+use Transbank\Webpay\Model\ResourceModel\WebpayOrderData\CollectionFactory;
+
+/**
+ * Class WebpayOrderDataRepository
+ * Repository for WebpayOrderData model
+ */
+class WebpayOrderDataRepository
+{
+    protected $webpayOrderDataFactory;
+    protected $collectionFactory;
+
+    /**
+     * Constructor
+     *
+     * @param WebpayOrderDataFactory $webpayOrderDataFactory Factory for creating WebpayOrderData instances
+     * @param CollectionFactory      $collectionFactory      Factory for creating Collection instances
+     */
+    public function __construct(
+        WebpayOrderDataFactory $webpayOrderDataFactory,
+        CollectionFactory $collectionFactory
+    ) {
+        $this->webpayOrderDataFactory = $webpayOrderDataFactory;
+        $this->collectionFactory = $collectionFactory;
+    }
+
+    /**
+     * Get WebpayOrderData by order ID and quote ID
+     *
+     * @param string $orderId The order ID
+     * @param string $quoteId The quote ID
+     *
+     * @return WebpayOrderData
+     */
+    public function getByOrderIdAndQuoteId($orderId, $quoteId)
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addFieldToFilter('order_id', $orderId)
+            ->addFieldToFilter('quote_id', $quoteId);
+
+        return $collection->getFirstItem();
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -20,4 +20,14 @@
             </argument>
         </arguments>
     </type>
+    <type name="Transbank\Webpay\Model\WebpayOrderDataFactory">
+        <arguments>
+            <argument name="objectManager" xsi:type="object">Magento\Framework\ObjectManagerInterface</argument>
+        </arguments>
+    </type>
+    <type name="Transbank\Webpay\Model\ResourceModel\WebpayOrderData\CollectionFactory">
+        <arguments>
+            <argument name="objectManager" xsi:type="object">Magento\Framework\ObjectManagerInterface</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
This PR adds a validation to prevent double authorization from occurring if the user reloads the page while authorizing a payment or manually calls the authorize endpoint.

## Test

### Authorization Ok
![image](https://github.com/user-attachments/assets/a918fda3-8c63-4327-ae6e-a5e9075144dd)

### Authorization error
![image](https://github.com/user-attachments/assets/610f1fa7-783b-428a-a0ef-0299a90ac8db)

### Reload page when payment is Ok
![image](https://github.com/user-attachments/assets/fdd413b5-0ede-49e9-94b6-bc0a36486003)

