### PR TITLE
feat: add webpay environment transaction info

### DIFF
--- a/Model/Webpay.php
+++ b/Model/Webpay.php
@@ -5,6 +5,7 @@ namespace Transbank\Webpay\Model;
 class Webpay extends \Magento\Payment\Model\Method\AbstractMethod
 {
     const CODE = 'transbank_webpay';
+    const PRODUCT_NAME = 'webpay_plus';
 
     /**
      * Payment code.


### PR DESCRIPTION
This PR add the Webpay Plus environment transaction information in webpay_order_data table.

## Test

Transaction in BD
<img width="1834" alt="image" src="https://github.com/user-attachments/assets/740bd1c6-0fbc-4926-a41b-9924d7769d5f">


Transaction Ok
![image](https://github.com/user-attachments/assets/359c8d47-50bd-4d5e-837f-4e74cea8726b)
