### PR TITLE
feat: use user id instead of the email

### DIFF
--- a/Controller/Transaction/AuthorizeOneclick.php
+++ b/Controller/Transaction/AuthorizeOneclick.php
@@ -446,10 +446,10 @@ class AuthorizeOneclick extends Action
     private function validatePayerMatchesCardInscription(OneclickInscriptionData $inscriptionData)
     {
         $customerData = $this->customerSession->getCustomerData();
-        $customerEmail = $customerData->getEmail();
-        $inscriptionEmail = $inscriptionData->getEmail();
+        $customerId = $customerData->getId();
+        $inscriptionUserId = $inscriptionData->getUserId();
 
-        return $customerEmail == $inscriptionEmail;
+        return $customerId == $inscriptionUserId;
     }
 
     /**


### PR DESCRIPTION
This PR refines the Oneclick authorization flow.

## Test

### Authorization Ok
![image](https://github.com/user-attachments/assets/914fd80b-2bd8-442b-9ab8-bcd5c6463ada)

### Authorization rejected
![image](https://github.com/user-attachments/assets/3b75e6ab-6539-4b4a-b77f-d9e8e0da3d13)

