### PR TITLE
chore: add dev container for magento

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,68 +1,71 @@
 FROM php:7.4-fpm-bullseye
 
-ARG MAGENTO_VERSION=2.4.3
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPOSER_VERSION=2.9.2
 
-# ---------- System dependencies ----------
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  apache2 \
-  cron \
-  ssh \
-  libicu-dev \
-  libxml2-dev \
-  libzip-dev \
-  libonig-dev \
-  libxslt1-dev \
-  libjpeg62-turbo-dev \
-  libpng-dev \
-  libfreetype6-dev \
-  git \
-  curl \
-  netcat-openbsd \
-  unzip \
-  bash \
-  ca-certificates \
-  default-mysql-client \
-  tzdata \
- && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    \
+    # ---------- System dependencies ----------
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        apache2 \
+        cron \
+        ssh \
+        libicu-dev \
+        libxml2-dev \
+        libzip-dev \
+        libonig-dev \
+        libxslt1-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libfreetype6-dev \
+        git \
+        curl \
+        netcat-openbsd \
+        unzip \
+        bash \
+        ca-certificates \
+        default-mysql-client \
+        tzdata; \
+    \
+    # ---------- PHP extensions ----------
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg; \
+    docker-php-ext-install -j"$(nproc)" \
+        bcmath \
+        intl \
+        mbstring \
+        pdo_mysql \
+        soap \
+        xsl \
+        zip \
+        sockets \
+        opcache \
+        gd; \
+    \
+    # ---------- PHP config ----------
+    echo "memory_limit=2G" > /usr/local/etc/php/conf.d/magento.ini; \
+    echo "max_execution_time=1800" >> /usr/local/etc/php/conf.d/magento.ini; \
+    echo "opcache.enable=1" > /usr/local/etc/php/conf.d/opcache.ini; \
+    echo "opcache.validate_timestamps=1" >> /usr/local/etc/php/conf.d/opcache.ini; \
+    \
+    # ---------- Apache config ----------
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf; \
+    a2enmod rewrite proxy proxy_fcgi headers; \
+    sed -i 's/Listen 80/Listen 8080/g' /etc/apache2/ports.conf; \
+    \
+    # ---------- Runtime dirs for apache ----------
+    mkdir -p /var/lock/apache2 /var/run/apache2 /var/www/html; \
+    chown -R www-data:www-data /var/lock/apache2 /var/run/apache2 /var/www/html; \
+    chmod -R 775 /var/lock/apache2 /var/run/apache2 /var/www/html; \
+    \
+    # ---------- Cleanup ----------
+    rm -rf /var/lib/apt/lists/*
 
-# ---------- PHP extensions ----------
-RUN docker-php-ext-configure gd \
-    --with-freetype \
-    --with-jpeg \
- && docker-php-ext-install -j$(nproc) \
-    bcmath \
-    intl \
-    mbstring \
-    pdo_mysql \
-    soap \
-    xsl \
-    zip \
-    sockets \
-    opcache \
-    gd
-
-# ---------- PHP config ----------
-RUN echo "memory_limit=2G" > /usr/local/etc/php/conf.d/magento.ini \
- && echo "max_execution_time=1800" >> /usr/local/etc/php/conf.d/magento.ini \
- && echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/opcache.ini \
- && echo "opcache.validate_timestamps=1" >> /usr/local/etc/php/conf.d/opcache.ini \
- && echo "ServerName localhost" >> /etc/apache2/apache2.conf
-
-# ---------- Apache config ----------
-RUN a2enmod rewrite proxy proxy_fcgi headers
 COPY .devcontainer/apache.conf /etc/apache2/sites-available/000-default.conf
 
-RUN sed -i 's/Listen 80/Listen 8080/g' /etc/apache2/ports.conf \
-    && sed -i 's/export APACHE_RUN_USER=www-data/export APACHE_RUN_USER=www-data/g' /etc/apache2/envvars \
-    && sed -i 's/export APACHE_RUN_GROUP=www-data/export APACHE_RUN_GROUP=www-data/g' /etc/apache2/envvars
-
-RUN mkdir -p /var/lock/apache2 /var/run/apache2 /var/www/html
-RUN chown -R www-data:www-data /var/lock/apache2 /var/run/apache2 /var/www/html
-RUN chmod -R 777 /var/lock/apache2 /var/run/apache2 /var/www/html
-
-# composer install
+# ---------- composer install ----------
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
  && php composer-setup.php --version=${COMPOSER_VERSION} --install-dir=/usr/local/bin --filename=composer \
  && php -r "unlink('composer-setup.php');" \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,71 @@
+FROM php:7.4-fpm-bullseye
+
+ARG MAGENTO_VERSION=2.4.3
+ENV DEBIAN_FRONTEND=noninteractive
+ENV COMPOSER_VERSION=2.9.2
+
+# ---------- System dependencies ----------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  apache2 \
+  cron \
+  ssh \
+  libicu-dev \
+  libxml2-dev \
+  libzip-dev \
+  libonig-dev \
+  libxslt1-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev \
+  libfreetype6-dev \
+  git \
+  curl \
+  netcat-openbsd \
+  unzip \
+  bash \
+  ca-certificates \
+  default-mysql-client \
+  tzdata \
+ && rm -rf /var/lib/apt/lists/*
+
+# ---------- PHP extensions ----------
+RUN docker-php-ext-configure gd \
+    --with-freetype \
+    --with-jpeg \
+ && docker-php-ext-install -j$(nproc) \
+    bcmath \
+    intl \
+    mbstring \
+    pdo_mysql \
+    soap \
+    xsl \
+    zip \
+    sockets \
+    opcache \
+    gd
+
+# ---------- PHP config ----------
+RUN echo "memory_limit=2G" > /usr/local/etc/php/conf.d/magento.ini \
+ && echo "max_execution_time=1800" >> /usr/local/etc/php/conf.d/magento.ini \
+ && echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/opcache.ini \
+ && echo "opcache.validate_timestamps=1" >> /usr/local/etc/php/conf.d/opcache.ini
+
+# ---------- Apache config ----------
+RUN a2enmod rewrite proxy proxy_fcgi headers
+COPY .devcontainer/apache.conf /etc/apache2/sites-available/000-default.conf
+
+# composer install
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+ && php composer-setup.php --version=${COMPOSER_VERSION} --install-dir=/usr/local/bin --filename=composer \
+ && php -r "unlink('composer-setup.php');" \
+ && composer --version
+
+# ---------- Magento ----------
+WORKDIR /var/www/html
+
+# ---------- Entrypoint ----------
+COPY .devcontainer/magento-setup.sh /usr/local/bin/magento-setup.sh
+RUN chmod +x /usr/local/bin/magento-setup.sh
+
+EXPOSE 80
+
+CMD ["bash", "-c", "php-fpm -D && apachectl -D FOREGROUND"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,11 +47,20 @@ RUN docker-php-ext-configure gd \
 RUN echo "memory_limit=2G" > /usr/local/etc/php/conf.d/magento.ini \
  && echo "max_execution_time=1800" >> /usr/local/etc/php/conf.d/magento.ini \
  && echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/opcache.ini \
- && echo "opcache.validate_timestamps=1" >> /usr/local/etc/php/conf.d/opcache.ini
+ && echo "opcache.validate_timestamps=1" >> /usr/local/etc/php/conf.d/opcache.ini \
+ && echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 # ---------- Apache config ----------
 RUN a2enmod rewrite proxy proxy_fcgi headers
 COPY .devcontainer/apache.conf /etc/apache2/sites-available/000-default.conf
+
+RUN sed -i 's/Listen 80/Listen 8080/g' /etc/apache2/ports.conf \
+    && sed -i 's/export APACHE_RUN_USER=www-data/export APACHE_RUN_USER=www-data/g' /etc/apache2/envvars \
+    && sed -i 's/export APACHE_RUN_GROUP=www-data/export APACHE_RUN_GROUP=www-data/g' /etc/apache2/envvars
+
+RUN mkdir -p /var/lock/apache2 /var/run/apache2 /var/www/html
+RUN chown -R www-data:www-data /var/lock/apache2 /var/run/apache2 /var/www/html
+RUN chmod -R 777 /var/lock/apache2 /var/run/apache2 /var/www/html
 
 # composer install
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
@@ -66,6 +75,8 @@ WORKDIR /var/www/html
 COPY .devcontainer/magento-setup.sh /usr/local/bin/magento-setup.sh
 RUN chmod +x /usr/local/bin/magento-setup.sh
 
-EXPOSE 80
+USER www-data
 
-CMD ["bash", "-c", "php-fpm -D && apachectl -D FOREGROUND"]
+EXPOSE 8080
+
+CMD ["bash", "-c", "php-fpm -D && . /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -66,6 +66,8 @@ Además:
 -   Se instalan productos de prueba
 -   Se configura la tienda automáticamente
 
+> ⚠️ **Nota**: En caso de tener la carpeta vendor o el archivo composer.lock dentro de la carpeta root del plugin, eliminar ambos por que pueden generar inconsistencia en la instalación del plugin.
+
 ### Desarrollo del módulo
 
 Los cambios en el plugin **no se reflejan automáticamente** en Magento. Se recomienda ejecutar los siguientes comandos después de cada cambio:
@@ -141,7 +143,7 @@ transbank-plugin-magento2-webpay-rest_devcontainer-magento
 3. Elimina los volúmenes:
 
 ```
-db_data
-es_data
-magento_data
+transbank-plugin-magento2-webpay-rest_devcontainer_db_data
+transbank-plugin-magento2-webpay-rest_devcontainer_es_data
+transbank-plugin-magento2-webpay-rest_devcontainer_magento_data
 ```

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -12,20 +12,20 @@ Este **devcontainer** proporciona un entorno completo de desarrollo para el mód
 
 ## 📋 Servicios incluidos
 
-- **Magento 2.4.3** con **PHP 7.4**
-- **MySQL 8** como base de datos
-- **Elasticsearch** para la búsqueda optimizada del catálogo
-- **Apache** como servidor web
-- **Extensiones de VS Code** para trabajar con PHP y Magento
-- **Composer** para la gestión de dependencias PHP
+-   **Magento 2.4.3** con **PHP 7.4**
+-   **MySQL 8** como base de datos
+-   **Elasticsearch** para la búsqueda optimizada del catálogo
+-   **Apache** como servidor web
+-   **Extensiones de VS Code** para trabajar con PHP y Magento
+-   **Composer** para la gestión de dependencias PHP
 
 ## 🔗 URLs de acceso
 
-| Servicio      | URL                         | Credenciales |
-|---------------|-----------------------------|--------------|
+| Servicio      | URL                         | Credenciales                                    |
+| ------------- | --------------------------- | ----------------------------------------------- |
 | Magento       | http://localhost:8000       | cliente@cliente.com / <ver variable de entorno> |
-| Panel Admin   | http://localhost:8000/admin | admin / admin |
-| Base de datos | VS Code SQLTools / MySQL    | magento / magento |
+| Panel Admin   | http://localhost:8000/admin | admin / admin123                                |
+| Base de datos | VS Code SQLTools / MySQL    | magento / magento                               |
 
 ## 🛠️ Herramientas de desarrollo
 
@@ -35,14 +35,14 @@ El devcontainer incluye extensiones para trabajar directamente con la base de da
 
 #### SQLTools
 
-- **Acceso**: `Ctrl/Cmd + Shift + P` → `SQLTools: Connect`
-- **Conexiones preconfiguradas**:
-  - **Magento MySQL** – Base de datos principal
-  - **MySQL Root** – Acceso administrativo completo
-- **Funcionalidades**:
-  - Exploración de tablas
-  - Ejecución de consultas
-  - Exportación de datos
+-   **Acceso**: `Ctrl/Cmd + Shift + P` → `SQLTools: Connect`
+-   **Conexiones preconfiguradas**:
+    -   **Magento MySQL** – Base de datos principal
+    -   **MySQL Root** – Acceso administrativo completo
+-   **Funcionalidades**:
+    -   Exploración de tablas
+    -   Ejecución de consultas
+    -   Exportación de datos
 
 ## 📁 Estructura del proyecto en el contenedor
 
@@ -61,9 +61,10 @@ El módulo Webpay se monta automáticamente en:
 ```
 
 Además:
-- Se activa el módulo
-- Se instalan productos de prueba
-- Se configura la tienda automáticamente
+
+-   Se activa el módulo
+-   Se instalan productos de prueba
+-   Se configura la tienda automáticamente
 
 ### Desarrollo del módulo
 
@@ -76,8 +77,9 @@ chmod -R 777 var generated pub
 ```
 
 Notas adicionales:
-- Los logs se almacenan en `.devcontainer/logs/`
-- La carpeta de Magento está incluida en **Intelephense** para contar con referencias del core
+
+-   Los logs se almacenan en `.devcontainer/logs/`
+-   La carpeta de Magento está incluida en **Intelephense** para contar con referencias del core
 
 ## 📦 Dependencias
 
@@ -94,11 +96,11 @@ composer require nueva-dependencia
 
 ### Configuración por defecto
 
-- **Host**: `db`
-- **Puerto**: `3306`
-- **Base de datos**: `magento`
-- **Usuario**: `magento`
-- **Contraseña**: `magento`
+-   **Host**: `db`
+-   **Puerto**: `3306`
+-   **Base de datos**: `magento`
+-   **Usuario**: `magento`
+-   **Contraseña**: `magento`
 
 ## 📝 Notas de desarrollo
 
@@ -113,8 +115,8 @@ Si se realizan cambios en el devcontainer, es necesario reconstruir la imagen pa
 
 ### Reconstruir el devcontainer
 
-- VS Code → Paleta de comandos → **Dev Containers: Rebuild Container**
-- O desde el menú Remote → **Reopen in Container**
+-   VS Code → Paleta de comandos → **Dev Containers: Rebuild Container**
+-   O desde el menú Remote → **Reopen in Container**
 
 > ⚠️ **Nota**: la reconstrucción elimina datos no persistentes. Realiza respaldos si es necesario.
 
@@ -123,6 +125,7 @@ Si se realizan cambios en el devcontainer, es necesario reconstruir la imagen pa
 Para realizar una instalación completamente limpia:
 
 1. Elimina los contenedores:
+
 ```
 magento-transbank-plugin-mysql
 magento-transbank-plugin-elastic
@@ -130,11 +133,13 @@ magento-transbank-plugin
 ```
 
 2. Elimina la imagen:
+
 ```
 transbank-plugin-magento2-webpay-rest_devcontainer-magento
 ```
 
 3. Elimina los volúmenes:
+
 ```
 db_data
 es_data

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,142 @@
+# DevContainer – Magento Webpay Module
+
+Este **devcontainer** proporciona un entorno completo de desarrollo para el módulo **Webpay de Magento**.
+
+## 🚀 Inicio rápido
+
+1. Abre el proyecto en **VS Code**.
+2. Cuando se te solicite, selecciona **“Reopen in Container”**.
+3. Espera a que se construya el contenedor (la primera vez puede tardar algunos minutos).
+4. Una vez listo, Magento estará disponible en:  
+   👉 **http://localhost:8000**
+
+## 📋 Servicios incluidos
+
+- **Magento 2.4.3** con **PHP 7.4**
+- **MySQL 8** como base de datos
+- **Elasticsearch** para la búsqueda optimizada del catálogo
+- **Apache** como servidor web
+- **Extensiones de VS Code** para trabajar con PHP y Magento
+- **Composer** para la gestión de dependencias PHP
+
+## 🔗 URLs de acceso
+
+| Servicio      | URL                         | Credenciales |
+|---------------|-----------------------------|--------------|
+| Magento       | http://localhost:8000       | cliente@cliente.com / <ver variable de entorno> |
+| Panel Admin   | http://localhost:8000/admin | admin / admin |
+| Base de datos | VS Code SQLTools / MySQL    | magento / magento |
+
+## 🛠️ Herramientas de desarrollo
+
+### Administración de base de datos con VS Code
+
+El devcontainer incluye extensiones para trabajar directamente con la base de datos.
+
+#### SQLTools
+
+- **Acceso**: `Ctrl/Cmd + Shift + P` → `SQLTools: Connect`
+- **Conexiones preconfiguradas**:
+  - **Magento MySQL** – Base de datos principal
+  - **MySQL Root** – Acceso administrativo completo
+- **Funcionalidades**:
+  - Exploración de tablas
+  - Ejecución de consultas
+  - Exportación de datos
+
+## 📁 Estructura del proyecto en el contenedor
+
+```
+/var/www/html/workspace/                                # Código fuente del plugin (montado desde el host)
+/var/www/html/                                          # Instalación de Magento
+/var/www/html/vendor/transbank/webpay-magento2-rest     # Módulo Webpay (enlazado desde /var/www/html/workspace)
+```
+
+## 🔧 Configuración del módulo
+
+El módulo Webpay se monta automáticamente en:
+
+```
+/var/www/html/vendor/transbank/webpay-magento2-rest
+```
+
+Además:
+- Se activa el módulo
+- Se instalan productos de prueba
+- Se configura la tienda automáticamente
+
+### Desarrollo del módulo
+
+Los cambios en el plugin **no se reflejan automáticamente** en Magento. Se recomienda ejecutar los siguientes comandos después de cada cambio:
+
+```bash
+rm -rf generated/code/* var/cache/* var/page_cache/* var/view_preprocessed/*
+php bin/magento cache:flush
+chmod -R 777 var generated pub
+```
+
+Notas adicionales:
+- Los logs se almacenan en `.devcontainer/logs/`
+- La carpeta de Magento está incluida en **Intelephense** para contar con referencias del core
+
+## 📦 Dependencias
+
+Las dependencias de **Composer** se instalan automáticamente la primera vez que se crea el contenedor.
+
+Para instalar nuevas dependencias manualmente:
+
+```bash
+cd /var/www/html
+composer require nueva-dependencia
+```
+
+## 🗄️ Base de datos
+
+### Configuración por defecto
+
+- **Host**: `db`
+- **Puerto**: `3306`
+- **Base de datos**: `magento`
+- **Usuario**: `magento`
+- **Contraseña**: `magento`
+
+## 📝 Notas de desarrollo
+
+1. **Permisos**: el usuario del contenedor es `root`, con acceso completo.
+2. **Persistencia**: los datos de Magento persisten entre reinicios.
+3. **Refresco de código**: no todos los cambios se reflejan automáticamente.
+4. **Logs**: disponibles en `.devcontainer/logs`.
+
+## 🧩 Edición del devcontainer
+
+Si se realizan cambios en el devcontainer, es necesario reconstruir la imagen para que estos se apliquen.
+
+### Reconstruir el devcontainer
+
+- VS Code → Paleta de comandos → **Dev Containers: Rebuild Container**
+- O desde el menú Remote → **Reopen in Container**
+
+> ⚠️ **Nota**: la reconstrucción elimina datos no persistentes. Realiza respaldos si es necesario.
+
+## 🔄 Forzar instalación limpia
+
+Para realizar una instalación completamente limpia:
+
+1. Elimina los contenedores:
+```
+magento-transbank-plugin-mysql
+magento-transbank-plugin-elastic
+magento-transbank-plugin
+```
+
+2. Elimina la imagen:
+```
+transbank-plugin-magento2-webpay-rest_devcontainer-magento
+```
+
+3. Elimina los volúmenes:
+```
+db_data
+es_data
+magento_data
+```

--- a/.devcontainer/apache.conf
+++ b/.devcontainer/apache.conf
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:8080>
   ServerName localhost
 
   DocumentRoot /var/www/html/pub

--- a/.devcontainer/apache.conf
+++ b/.devcontainer/apache.conf
@@ -1,0 +1,17 @@
+<VirtualHost *:80>
+  ServerName localhost
+
+  DocumentRoot /var/www/html/pub
+
+  <Directory /var/www/html/pub>
+    AllowOverride All
+    Require all granted
+  </Directory>
+
+  <FilesMatch \.php$>
+    SetHandler "proxy:fcgi://127.0.0.1:9000"
+  </FilesMatch>
+
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,21 +1,21 @@
 {
-  "name": "Magento 2.4.3 (PHP 7.4) + Transbank Module",
-  "dockerComposeFile": ["./docker-compose.yml"],
-  "service": "magento",
-  "workspaceFolder": "/var/www/html/workspace",
-  "runServices": ["db", "elasticsearch", "magento"],
-  "remoteUser": "root",
-  "shutdownAction": "stopCompose",
-  "postCreateCommand": "/usr/local/bin/magento-setup.sh",
-  "mounts": [
-    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
-  ],
-  "features": {
-    "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {
-      "plugins": "git zsh-autosuggestions zsh-syntax-highlighting"
-    }
-  },
-  "customizations": {
+    "name": "Magento 2.4.3 (PHP 7.4) + Transbank Module",
+    "dockerComposeFile": ["./docker-compose.yml"],
+    "service": "magento",
+    "workspaceFolder": "/var/www/html/workspace",
+    "runServices": ["db", "elasticsearch", "magento"],
+    "remoteUser": "root",
+    "shutdownAction": "stopCompose",
+    "postCreateCommand": "/usr/local/bin/magento-setup.sh",
+    "mounts": [
+        "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+    ],
+    "features": {
+        "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {
+            "plugins": "git zsh-autosuggestions zsh-syntax-highlighting"
+        }
+    },
+    "customizations": {
         "vscode": {
             "settings": {
                 "explorer.confirmDelete": false,
@@ -42,7 +42,9 @@
                 "settingsSync.enabled": false,
                 "remote.extensionKind": {
                     "github.copilot": ["ui"],
-                    "github.copilot-chat": ["ui"]
+                    "github.copilot-chat": ["ui"],
+                    "mtxr.sqltools": ["ui", "workspace"],
+                    "mtxr.sqltools-driver-mysql": ["workspace"]
                 },
                 "files.watcherExclude": {
                     "**/vendor/**": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,117 @@
+{
+  "name": "Magento 2.4.3 (PHP 7.4) + Transbank Module",
+  "dockerComposeFile": ["./docker-compose.yml"],
+  "service": "magento",
+  "workspaceFolder": "/var/www/html/workspace",
+  "runServices": ["db", "elasticsearch", "magento"],
+  "remoteUser": "root",
+  "shutdownAction": "stopCompose",
+  "postCreateCommand": "/usr/local/bin/magento-setup.sh",
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+  ],
+  "features": {
+    "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {
+      "plugins": "git zsh-autosuggestions zsh-syntax-highlighting"
+    }
+  },
+  "customizations": {
+        "vscode": {
+            "settings": {
+                "explorer.confirmDelete": false,
+                "editor.bracketPairColorization.enabled": true,
+                "editor.guides.bracketPairs": true,
+                "editor.autoClosingBrackets": "always",
+                "editor.linkedEditing": true,
+                "editor.fontLigatures": true,
+                "editor.suggestSelection": "first",
+                "editor.inlineSuggest.enabled": true,
+                "editor.guides.bracketPairsHorizontal": true,
+                "editor.unicodeHighlight.invisibleCharacters": false,
+                "editor.codeLens": true,
+                "editor.formatOnSave": true,
+                "editor.rulers": [120],
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
+                "files.insertFinalNewline": true,
+                "github.copilot.nextEditSuggestions.enabled": true,
+                "git.enableCommitSigning": false,
+                "extensions.autoUpdate": false,
+                "extensions.autoCheckUpdates": false,
+                "extensions.ignoreRecommendations": true,
+                "remote.containers.installRecommendedExtensions": false,
+                "settingsSync.enabled": false,
+                "remote.extensionKind": {
+                    "github.copilot": ["ui"],
+                    "github.copilot-chat": ["ui"]
+                },
+                "files.watcherExclude": {
+                    "**/vendor/**": true,
+                    "**/var/cache/**": true,
+                    "**/node_modules/**": true
+                },
+                "sqltools.connections": [
+                    {
+                        "name": "Magento Mysql",
+                        "driver": "MySQL",
+                        "server": "db",
+                        "port": 3306,
+                        "database": "magento",
+                        "username": "magento",
+                        "password": "magento",
+                        "connectionTimeout": 60000,
+                        "previewLimit": 50,
+                        "group": "Development"
+                    },
+                    {
+                        "name": "Mysql Root",
+                        "driver": "MySQL",
+                        "server": "db",
+                        "port": 3306,
+                        "database": "",
+                        "username": "root",
+                        "password": "magento",
+                        "connectionTimeout": 60000,
+                        "previewLimit": 50,
+                        "group": "Administration"
+                    }
+                ],
+                "sqltools.autoOpenSessionFiles": false,
+                "sqltools.format": {
+                    "language": "sql",
+                    "indent": "  "
+                },
+                "sqltools.defaultExportType": "csv",
+                "php.executablePath": "/usr/local/bin/php",
+                "php.validate.executablePath": "/usr/local/bin/php",
+                "intelephense.files.maxSize": 5000000,
+                "intelephense.environment.includePaths": ["/var/www/html"],
+                "[php]": {
+                    "editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
+                },
+                "[jsonc]": {
+                    "editor.defaultFormatter": "esbenp.prettier-vscode"
+                },
+                "prettier.trailingComma": "none"
+            },
+            "extensions": [
+                "ms-vsliveshare.vsliveshare", // Live Share
+                "ms-vscode.vscode-json", // JSON Support
+                "github.vscode-github-actions", // GitHub Actions
+                "fill-labs.dependi", // Dependi
+                "usernamehw.errorlens", // Error Lens
+                "esbenp.prettier-vscode", // Prettier
+                "editorconfig.editorconfig", // EditorConfig
+                "kisstkondoros.vscode-gutter-preview", // Gutter Preview
+                "gruntfuggly.todo-tree", // TODO Tree
+                "mtxr.sqltools", // SQLTools
+                "mtxr.sqltools-driver-mysql", // SQLTools MySQL Driver
+                "DEVSENSE.phptools-vscode", // PHP Tools
+                "bmewburn.vscode-intelephense-client", // Intelephense
+                "hakcorp.php-awesome-snippets", // PHP Awesome Snippets
+                "formulahendry.auto-rename-tag", // Auto Rename Tag
+                "bradgashler.htmltagwrap", // HTML Tag Wrap
+                "adpyke.codesnap" // CodeSnap
+            ]
+        }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       MAGENTO_ADMIN_USER: admin
       MAGENTO_ADMIN_PASSWORD: admin123
       MAGENTO_ADMIN_EMAIL: admin@admin.com
+      MAGENTO_VERSION: 2.4.3
 volumes:
   db_data:
   es_data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - db
       - elasticsearch
     ports:
-      - "8000:80"
+      - "8000:8080"
     volumes:
       - ..:/var/www/html/workspace:cached
       - magento_data:/var/www/html

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,78 @@
+version: "3.8"
+
+services:
+  db:
+    platform: linux/x86_64
+    image: mysql:8.0
+    container_name: magento-transbank-plugin-mysql
+    restart: on-failure:2
+    command: >
+      --default-time-zone='America/Santiago'
+      --default-authentication-plugin=mysql_native_password --sql-mode=""
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-pmagento"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    environment:
+      MYSQL_ROOT_PASSWORD: magento
+      MYSQL_DATABASE: magento
+      MYSQL_USER: magento
+      MYSQL_PASSWORD: magento
+    volumes:
+      - db_data:/var/lib/mysql
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    container_name: magento-transbank-plugin-elastic
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms256m -Xmx256m"
+      TZ: America/Santiago
+    restart: on-failure:2
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fsS http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow\\&timeout=5s >/dev/null || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+  magento:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    container_name: magento-transbank-plugin
+    depends_on:
+      - db
+      - elasticsearch
+    ports:
+      - "8000:80"
+    volumes:
+      - ..:/var/www/html/workspace:cached
+      - magento_data:/var/www/html
+      - ./logs/magento:/var/www/html/var/log
+      - ./logs/report:/var/www/html/var/report
+      - ./logs/apache:/var/log/apache2
+    environment:
+      CUSTOMER_EMAIL: cliente@cliente.com
+      CUSTOMER_PASSWORD: cliente123!
+      PLUGIN_NAME: transbank/webpay-magento2-rest
+      MAGENTO_DIR: /var/www/html
+      MAGENTO_STORE_PORT: 8000
+      INSTALL_PLUGIN_DEV_DEPS: 0
+      MAGENTO_DB_HOST: db
+      MAGENTO_DB_NAME: magento
+      MAGENTO_DB_USER: magento
+      MAGENTO_DB_PASSWORD: magento
+      MAGENTO_ADMIN_USER: admin
+      MAGENTO_ADMIN_PASSWORD: admin123
+      MAGENTO_ADMIN_EMAIL: admin@admin.com
+volumes:
+  db_data:
+  es_data:
+  magento_data:

--- a/.devcontainer/magento-setup.sh
+++ b/.devcontainer/magento-setup.sh
@@ -6,35 +6,62 @@ MAGENTO_VERSION="2.4.3"
 MAGENTO_ZIP_URL="github.com/magento/magento2/archive/refs/tags/${MAGENTO_VERSION}.zip"
 PLUGIN_SRC="${MAGENTO_DIR}/workspace"
 
-log() { echo -e "\n\033[1;32m==>\033[0m $*"; }
+log() {
+  echo -e "\n\033[1;32m==>\033[0m $*"
+  return 0
+}
 
 # --- Utility functions
 wait_port() {
   local host="$1" port="$2" name="$3"
+
   log "Esperando ${name} (${host}:${port})"
-  timeout 60s bash -c "until nc -z $host $port; do sleep 2; done" && echo "${name} listo" || (echo "ERROR: ${name} no respondió" && exit 1)
+
+  if timeout 60s bash -c "until nc -z $host $port; do sleep 2; done"; then
+    echo "${name} listo"
+    return 0
+  else
+    echo "ERROR: ${name} no respondió" >&2
+    return 1
+  fi
 }
 
 wait_es_yellow() {
   log "Esperando Elasticsearch"
-  timeout 90s bash -c "until curl -fsS 'http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=5s' >/dev/null; do sleep 2; done" && echo "ES listo" || (echo "ERROR: ES falló" && exit 1)
+
+  if timeout 90s bash -c "until curl -fsS 'http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=5s' >/dev/null; do sleep 2; done"; then
+    echo "ES listo"
+    return 0
+  else
+    echo "ERROR: ES falló" >&2
+    return 1
+  fi
 }
 
 cleanup_transbank_null_config() {
   log "Limpiando core_config_data (NULL/vacío)..."
-  mysql -h "${MAGENTO_DB_HOST}" -u "${MAGENTO_DB_USER}" -p"${MAGENTO_DB_PASSWORD}" "${MAGENTO_DB_NAME}" -e "
-  DELETE FROM core_config_data WHERE path LIKE 'payment/transbank_%' AND (value IS NULL OR TRIM(value) = '');
-  " || true
+
+  mysql -h "${MAGENTO_DB_HOST}" \
+        -u "${MAGENTO_DB_USER}" \
+        -p"${MAGENTO_DB_PASSWORD}" \
+        "${MAGENTO_DB_NAME}" \
+        -e "
+DELETE FROM core_config_data
+WHERE path LIKE 'payment/transbank_%'
+  AND (value IS NULL OR TRIM(value) = '');
+" || true
+
+  return 0
 }
 
 # --- Wait for MySQL and Elasticsearch
-wait_port db 3306 "MySQL"
-wait_es_yellow
+wait_port db 3306 "MySQL" || exit 1
+wait_es_yellow || exit 1
 
 cd "$MAGENTO_DIR"
 
 # --- 1. Magento installation (Only if it doesn't exist)
-if [ ! -f "bin/magento" ]; then
+if [[ ! -f "bin/magento" ]]; then
     log "Descargando Magento ${MAGENTO_VERSION}..."
     curl -fsSL "${MAGENTO_ZIP_URL}" -o /tmp/magento.zip
     unzip -q /tmp/magento.zip -d /tmp/magento-src
@@ -59,7 +86,7 @@ if ! grep -q "local-plugin" composer.json; then
 fi
 
 # --- 3. Install/Update Plugin
-if [ -f "${PLUGIN_SRC}/composer.json" ]; then
+if [[ -f "${PLUGIN_SRC}/composer.json" ]]; then
 
     REAL_PLUGIN_NAME=$(grep '"name":' "${PLUGIN_SRC}/composer.json" | cut -d'"' -f4)
 
@@ -75,7 +102,7 @@ if [ -f "${PLUGIN_SRC}/composer.json" ]; then
 fi
 
 # --- 4. Database setup and installation
-if [ ! -f "app/etc/env.php" ]; then
+if [[ ! -f "app/etc/env.php" ]]; then
     log "Ejecutando setup:install inicial..."
     php bin/magento setup:install \
         --base-url="http://localhost:${MAGENTO_STORE_PORT}" \
@@ -117,7 +144,7 @@ php bin/magento setup:di:compile
 
 # --- 6. Demo Data
 DEMO_FLAG="${MAGENTO_DIR}/var/.demo-data-installed"
-if [ ! -f "${DEMO_FLAG}" ] && [ -f "${PLUGIN_SRC}/.devcontainer/setup-demo-data.php" ]; then
+if [[ ! -f "${DEMO_FLAG}" ]] && [[ -f "${PLUGIN_SRC}/.devcontainer/setup-demo-data.php" ]]; then
     log "Instalando datos demo..."
     php "${PLUGIN_SRC}/.devcontainer/setup-demo-data.php"
     touch "${DEMO_FLAG}"

--- a/.devcontainer/magento-setup.sh
+++ b/.devcontainer/magento-setup.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 # --- Environment Variables
-MAGENTO_VERSION="2.4.3"
 MAGENTO_ZIP_URL="https://github.com/magento/magento2/archive/refs/tags/${MAGENTO_VERSION}.zip"
 PLUGIN_SRC="${MAGENTO_DIR}/workspace"
 

--- a/.devcontainer/magento-setup.sh
+++ b/.devcontainer/magento-setup.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Environment Variables
+MAGENTO_VERSION="2.4.3"
+MAGENTO_ZIP_URL="github.com/magento/magento2/archive/refs/tags/${MAGENTO_VERSION}.zip"
+PLUGIN_SRC="${MAGENTO_DIR}/workspace"
+
+log() { echo -e "\n\033[1;32m==>\033[0m $*"; }
+
+# --- Utility functions
+wait_port() {
+  local host="$1" port="$2" name="$3"
+  log "Esperando ${name} (${host}:${port})"
+  timeout 60s bash -c "until nc -z $host $port; do sleep 2; done" && echo "${name} listo" || (echo "ERROR: ${name} no respondió" && exit 1)
+}
+
+wait_es_yellow() {
+  log "Esperando Elasticsearch"
+  timeout 90s bash -c "until curl -fsS 'http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=5s' >/dev/null; do sleep 2; done" && echo "ES listo" || (echo "ERROR: ES falló" && exit 1)
+}
+
+cleanup_transbank_null_config() {
+  log "Limpiando core_config_data (NULL/vacío)..."
+  mysql -h "${MAGENTO_DB_HOST}" -u "${MAGENTO_DB_USER}" -p"${MAGENTO_DB_PASSWORD}" "${MAGENTO_DB_NAME}" -e "
+  DELETE FROM core_config_data WHERE path LIKE 'payment/transbank_%' AND (value IS NULL OR TRIM(value) = '');
+  " || true
+}
+
+# --- Wait for MySQL and Elasticsearch
+wait_port db 3306 "MySQL"
+wait_es_yellow
+
+cd "$MAGENTO_DIR"
+
+# --- 1. Magento installation (Only if it doesn't exist)
+if [ ! -f "bin/magento" ]; then
+    log "Descargando Magento ${MAGENTO_VERSION}..."
+    curl -fsSL "${MAGENTO_ZIP_URL}" -o /tmp/magento.zip
+    unzip -q /tmp/magento.zip -d /tmp/magento-src
+    SRC_FOLDER=$(find /tmp/magento-src -maxdepth 1 -type d -name "magento2-*" | head -n 1)
+    cp -a "${SRC_FOLDER}/." .
+    rm -rf /tmp/magento-src /tmp/magento.zip
+
+    composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+    composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true
+    composer config --no-interaction allow-plugins.magento/magento-composer-installer true
+    composer install --no-interaction --prefer-dist
+fi
+
+# --- 2. Configure local repository
+log "Verificando repositorio local..."
+
+# Add repository only if it doesn't exist in Magento's composer.json
+if ! grep -q "local-plugin" composer.json; then
+    composer config repositories.local-plugin path "${PLUGIN_SRC}"
+    composer config minimum-stability dev
+    composer config prefer-stable true
+fi
+
+# --- 3. Install/Update Plugin
+if [ -f "${PLUGIN_SRC}/composer.json" ]; then
+
+    REAL_PLUGIN_NAME=$(grep '"name":' "${PLUGIN_SRC}/composer.json" | cut -d'"' -f4)
+
+    if composer show "$REAL_PLUGIN_NAME" >/dev/null 2>&1; then
+        log "Actualizando plugin: ${REAL_PLUGIN_NAME}..."
+
+        rm -rf "vendor/${REAL_PLUGIN_NAME}"
+        composer update "$REAL_PLUGIN_NAME" --no-interaction
+    else
+        log "Instalando plugin por primera vez: ${REAL_PLUGIN_NAME}..."
+        composer require "${REAL_PLUGIN_NAME}:@dev" --no-interaction
+    fi
+fi
+
+# --- 4. Database setup and installation
+if [ ! -f "app/etc/env.php" ]; then
+    log "Ejecutando setup:install inicial..."
+    php bin/magento setup:install \
+        --base-url="http://localhost:${MAGENTO_STORE_PORT}" \
+        --db-host=${MAGENTO_DB_HOST} \
+        --db-name=${MAGENTO_DB_NAME} \
+        --db-user=${MAGENTO_DB_USER} \
+        --db-password=${MAGENTO_DB_PASSWORD} \
+        --backend-frontname=admin \
+        --admin-user=${MAGENTO_ADMIN_USER} \
+        --admin-password=${MAGENTO_ADMIN_PASSWORD} \
+        --admin-email=${MAGENTO_ADMIN_EMAIL} \
+        --admin-firstname=Admin \
+        --admin-lastname=User \
+        --language=es_CL \
+        --currency=CLP \
+        --timezone=America/Santiago \
+        --use-rewrites=1 \
+        --search-engine=elasticsearch7 \
+        --elasticsearch-host=elasticsearch \
+        --elasticsearch-port=9200 \
+        --cleanup-database \
+        --enable-modules=Transbank_Webpay
+
+    log "Instalando cron"
+    php bin/magento cron:install || true
+else
+    log "Magento ya instalado. Sincronizando posibles cambios en el plugin..."
+    php bin/magento setup:upgrade --keep-generated
+fi
+
+# --- 5. Code and Cache Refresh
+log "Limpiando archivos generados y compilando..."
+
+rm -rf generated/code/* generated/metadata/* var/cache/* var/page_cache/* var/view_preprocessed/* pub/static/frontend/* pub/static/adminhtml/*
+
+php bin/magento deploy:mode:set developer || true
+cleanup_transbank_null_config
+php bin/magento setup:di:compile
+
+# --- 6. Demo Data
+DEMO_FLAG="${MAGENTO_DIR}/var/.demo-data-installed"
+if [ ! -f "${DEMO_FLAG}" ] && [ -f "${PLUGIN_SRC}/.devcontainer/setup-demo-data.php" ]; then
+    log "Instalando datos demo..."
+    php "${PLUGIN_SRC}/.devcontainer/setup-demo-data.php"
+    touch "${DEMO_FLAG}"
+fi
+
+php bin/magento indexer:reindex
+php bin/magento cache:flush
+
+# Directory Permissions
+mkdir -p var generated pub
+chmod -R 777 var generated pub
+chown -R www-data:www-data var generated pub
+
+log "¡Listo! Accede en http://localhost:${MAGENTO_STORE_PORT}"

--- a/.devcontainer/magento-setup.sh
+++ b/.devcontainer/magento-setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # --- Environment Variables
 MAGENTO_VERSION="2.4.3"
-MAGENTO_ZIP_URL="github.com/magento/magento2/archive/refs/tags/${MAGENTO_VERSION}.zip"
+MAGENTO_ZIP_URL="https://github.com/magento/magento2/archive/refs/tags/${MAGENTO_VERSION}.zip"
 PLUGIN_SRC="${MAGENTO_DIR}/workspace"
 
 log() {

--- a/.devcontainer/setup-demo-data.php
+++ b/.devcontainer/setup-demo-data.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\App\Bootstrap;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+$magentoPath = getenv('MAGENTO_DIR') ?: '/var/www/html';
+$bootstrapFile = rtrim($magentoPath, '/') . '/app/bootstrap.php';
+
+require $bootstrapFile;
+
+$params = $_SERVER;
+$bootstrap = Bootstrap::create(BP, $params);
+$objectManager = $bootstrap->getObjectManager();
+
+// Configurar el área es vital para evitar errores de plantillas/traducciones
+$state = $objectManager->get(\Magento\Framework\App\State::class);
+try {
+    $state->setAreaCode('adminhtml');
+} catch (\Exception $e) {
+}
+
+/** CONFIG */
+$websiteId = 1;
+$customerEmail = getenv('CUSTOMER_EMAIL') ?: 'cliente@cliente.com';
+$customerPassword = getenv('CUSTOMER_PASSWORD') ?: 'cliente';
+$productSku = 'cw12201';
+
+/** CLIENTE */
+$customerRepo = $objectManager->get(\Magento\Customer\Api\CustomerRepositoryInterface::class);
+$customerFactory = $objectManager->get(\Magento\Customer\Api\Data\CustomerInterfaceFactory::class);
+$accountManagement = $objectManager->get(\Magento\Customer\Api\AccountManagementInterface::class);
+
+try {
+    $customerRepo->get($customerEmail);
+    echo "Cliente ya existe: {$customerEmail}\n";
+} catch (NoSuchEntityException $e) {
+    $customer = $customerFactory->create();
+    $customer->setWebsiteId($websiteId);
+    $customer->setEmail($customerEmail);
+    $customer->setFirstname('Cliente');
+    $customer->setLastname('Demo');
+    $accountManagement->createAccount($customer, $customerPassword);
+    echo "Cliente creado: {$customerEmail}\n";
+}
+
+/** PRODUCTO */
+$productRepo = $objectManager->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+$productFactory = $objectManager->get(\Magento\Catalog\Api\Data\ProductInterfaceFactory::class);
+
+try {
+    $productRepo->get($productSku);
+    echo "Producto ya existe: {$productSku}\n";
+} catch (NoSuchEntityException $e) {
+    $product = $productFactory->create();
+    $product->setSku($productSku);
+    $product->setName('Producto Demo');
+    $product->setPrice(1200);
+    $product->setAttributeSetId(4);
+    $product->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED);
+    $product->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH);
+    $product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE);
+    $product->setWebsiteIds([$websiteId]);
+
+    $product->setCustomAttribute('tax_class_id', 2);
+
+    $product->setStockData([
+        'use_config_manage_stock' => 0,
+        'manage_stock' => 1,
+        'is_in_stock' => 1,
+        'qty' => 1000
+    ]);
+
+    $productRepo->save($product);
+    echo "Producto creado: {$productSku}\n";
+}
+
+echo "\nDemo data OK\n";

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ development-docker/.built
 development-docker/plugin/*
 
 .vscode
+.devcontainer/logs


### PR DESCRIPTION
The dev environment uses Docker Compose and a custom shell configuration. The plugin code is volume-mounted and linked via Composer for automatic dependency installation. Webpay and Oneclick are enabled by default. The setup includes pre-defined admin/customer accounts and a test product.