### PR TITLE
feat: refine webpay return

### DIFF
--- a/.devcontainer/setup-demo-data.php
+++ b/.devcontainer/setup-demo-data.php
@@ -34,7 +34,7 @@ $accountManagement = $objectManager->get(\Magento\Customer\Api\AccountManagement
 
 try {
     $customerRepo->get($customerEmail);
-    echo "Cliente ya existe: {$customerEmail}\n";
+    echo "Cliente ya existe\n";
 } catch (NoSuchEntityException $e) {
     $customer = $customerFactory->create();
     $customer->setWebsiteId($websiteId);
@@ -42,7 +42,7 @@ try {
     $customer->setFirstname('Cliente');
     $customer->setLastname('Demo');
     $accountManagement->createAccount($customer, $customerPassword);
-    echo "Cliente creado: {$customerEmail}\n";
+    echo "Cliente creado\n";
 }
 
 /** PRODUCTO */

--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -1,0 +1,19 @@
+name: Kiuwan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  scan:
+    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@2a2837602d7636c5f31f97209ae60a0fe74c2c94
+    with:
+      project_name: td-webpay-plugin-magento2
+      source_path: .
+      fail_on_audit: true
+    secrets:
+      VPN_CONFIG_B64: ${{ secrets.VPN_CONFIG_B64 }}
+      VPN_USER: ${{ secrets.VPN_USER }}
+      VPN_PASS: ${{ secrets.VPN_PASS }}
+      KIUWAN_USER: ${{ secrets.KIUWAN_USER }}
+      KIUWAN_PASS: ${{ secrets.KIUWAN_PASS }}

--- a/.github/workflows/kiuwan.yml
+++ b/.github/workflows/kiuwan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@2a2837602d7636c5f31f97209ae60a0fe74c2c94
+    uses: TransbankDevelopers/transbank-github-actions-templates/.github/workflows/kiuwan-pr-scan.yml@02f92d3b1c1b56c6242aa7c76eb9479fd82187aa
     with:
       project_name: td-webpay-plugin-magento2
       source_path: .

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -6,6 +6,7 @@ use Throwable;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Transbank\Webpay\Exceptions\EcommerceException;
+use Transbank\Webpay\Exceptions\MySqlNamedLockException;
 use Transbank\Webpay\Helper\ObjectManagerHelper;
 use Transbank\Webpay\Model\TransbankSdkWebpayRest;
 use Transbank\Webpay\Model\WebpayOrderData;

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -158,7 +158,6 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     private function handleNormalFlow(string $token)
     {
         $lockAcquired = false;
-        $responseHandled = null;
         $this->log->logInfo('Procesando transacción por flujo Normal => token: ' . $token);
 
         try {
@@ -172,30 +171,33 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
                 return $this->handleTransactionAlreadyProcessed($token);
             }
 
-            $config = $this->configProvider->getPluginConfig();
-            $webpayOrderData = $this->getWebpayOrderData($token);
-            $orderId = $webpayOrderData->getOrderId();
-            $order = $this->getOrder($orderId);
-
-            $transbankSdkWebpay = new TransbankSdkWebpayRest($config);
-            $commitResponse = $transbankSdkWebpay->commitTransaction($token);
-
-            if (is_array($commitResponse) && isset($commitResponse['error'])) {
-                return $this->handleFlowError($token);
-            }
-
-            $webpayOrderData->setMetadata(json_encode($commitResponse));
-
-            if ($commitResponse->isApproved()) {
-                $responseHandled = $this->handleAuthorizedTransaction($order, $webpayOrderData, $commitResponse);
-            } else {
-                $responseHandled = $this->handleUnauthorizedTransaction($order, $webpayOrderData, $commitResponse);
-            }
+            return $this->processTransaction($token);
         } finally {
             $this->releaseWebpayReturnLock($token, $lockAcquired);
         }
+    }
 
-        return $responseHandled;
+    private function processTransaction(string $token)
+    {
+        $config = $this->configProvider->getPluginConfig();
+        $webpayOrderData = $this->getWebpayOrderData($token);
+        $orderId = $webpayOrderData->getOrderId();
+        $order = $this->getOrder($orderId);
+
+        $transbankSdkWebpay = new TransbankSdkWebpayRest($config);
+        $commitResponse = $transbankSdkWebpay->commitTransaction($token);
+
+        if (is_array($commitResponse) && isset($commitResponse['error'])) {
+            return $this->handleFlowError($token);
+        }
+
+        $webpayOrderData->setMetadata(json_encode($commitResponse));
+
+        if ($commitResponse->isApproved()) {
+            return $this->handleAuthorizedTransaction($order, $webpayOrderData, $commitResponse);
+        }
+
+        return $this->handleUnauthorizedTransaction($order, $webpayOrderData, $commitResponse);
     }
 
     /**
@@ -206,16 +208,10 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
      */
     private function acquireWebpayReturnLock(string $token): bool
     {
-        $lockAcquired = false;
+        $lockAcquired = $this->webpayReturnLock->acquire($token);
 
-        try {
-            $lockAcquired = $this->webpayReturnLock->acquire($token);
-
-            if (!$lockAcquired) {
-                $this->log->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
-            }
-        } catch (\Throwable $e) {
-            $this->log->logError("Error al adquirir el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
+        if (!$lockAcquired) {
+            $this->log->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
         }
 
         return $lockAcquired;

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -6,7 +6,6 @@ use Throwable;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Transbank\Webpay\Exceptions\EcommerceException;
-use Transbank\Webpay\Exceptions\MySqlNamedLockException;
 use Transbank\Webpay\Helper\ObjectManagerHelper;
 use Transbank\Webpay\Model\TransbankSdkWebpayRest;
 use Transbank\Webpay\Model\WebpayOrderData;
@@ -237,7 +236,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
             if (!$released) {
                 $this->log->logWarning("No se pudo liberar el lock de retorno de Webpay token => {$token}");
             }
-        } catch (MySqlNamedLockException $e) {
+        } catch (\Throwable $e) {
             $this->log->logError("Error al liberar el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
         }
     }

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -217,8 +217,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
 
             return $lockAcquired;
         } catch (\Throwable $e) {
-            $this->log->logError("Error al adquirir el lock de retorno de Webpay => token: {$token} - Error: {$e->getMessage()}");
-            throw $e;
+            $this->log->logError("Error al adquirir el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
         }
     }
 
@@ -242,7 +241,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
                 $this->log->logWarning("No se pudo liberar el lock de retorno de Webpay token => {$token}");
             }
         } catch (\Throwable $e) {
-            $this->log->logWarning("Error al liberar el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
+            $this->log->logError("Error al liberar el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
         }
     }
 

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -12,6 +12,7 @@ use Transbank\Webpay\Model\WebpayOrderData;
 use Transbank\Webpay\Helper\PluginLogger;
 use Transbank\Webpay\Helper\QuoteHelper;
 use Transbank\Webpay\Helper\TbkResponseHelper;
+use Transbank\Webpay\Infrastructure\Lock\MySqlNamedLock;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 
 /**
@@ -30,6 +31,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     const WEBPAY_TIMEOUT_FLOW_MESSAGE = 'Orden cancelada por inactividad del usuario en el formulario de pago.';
     const WEBPAY_ERROR_FLOW_MESSAGE = 'Orden cancelada por un error en el formulario de pago';
     const WEBPAY_EXCEPTION_FLOW_MESSAGE = 'No se pudo procesar el pago.';
+    const WEBPAY_OPERATION_IN_PROGRESS_MESSAGE = 'Ya estamos procesando tu solicitud. Por favor, espera unos momentos antes de volver a intentarlo.';
 
     protected $configProvider;
     protected $checkoutSession;
@@ -41,6 +43,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
     protected $log;
     protected $messageManager;
     private $quoteHelper;
+    private MySqlNamedLock $webpayReturnLock;
 
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
@@ -51,7 +54,8 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Transbank\Webpay\Model\Config\ConfigProvider $configProvider,
         \Transbank\Webpay\Model\WebpayOrderDataFactory $webpayOrderDataFactory,
-        QuoteHelper $quoteHelper
+        QuoteHelper $quoteHelper,
+        MySqlNamedLock $webpayReturnLock
     ) {
         parent::__construct($context);
 
@@ -65,6 +69,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
         $this->webpayOrderDataFactory = $webpayOrderDataFactory;
         $this->log = new PluginLogger();
         $this->quoteHelper = $quoteHelper;
+        $this->webpayReturnLock = $webpayReturnLock;
     }
 
     /**
@@ -152,35 +157,92 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
 
     private function handleNormalFlow(string $token)
     {
+        $lockAcquired = false;
+        $responseHandled = null;
         $this->log->logInfo('Procesando transacción por flujo Normal => token: ' . $token);
 
-        if ($this->checkTransactionIsAlreadyProcessed($token)) {
-            return $this->handleTransactionAlreadyProcessed($token);
-        }
+        try {
+            $lockAcquired = $this->acquireWebpayReturnLock($token);
 
-        $config = $this->configProvider->getPluginConfig();
-        $webpayOrderData = $this->getWebpayOrderData($token);
-        $orderId = $webpayOrderData->getOrderId();
-        $order = $this->getOrder($orderId);
+            if (!$lockAcquired) {
+                return $this->redirectWithErrorMessage(self::WEBPAY_OPERATION_IN_PROGRESS_MESSAGE);
+            }
 
-        $transbankSdkWebpay = new TransbankSdkWebpayRest($config);
-        $commitResponse = $transbankSdkWebpay->commitTransaction($token);
+            if ($this->checkTransactionIsAlreadyProcessed($token)) {
+                return $this->handleTransactionAlreadyProcessed($token);
+            }
 
-        if (is_array($commitResponse) && isset($commitResponse['error'])) {
-            return $this->handleFlowError($token);
-        }
+            $config = $this->configProvider->getPluginConfig();
+            $webpayOrderData = $this->getWebpayOrderData($token);
+            $orderId = $webpayOrderData->getOrderId();
+            $order = $this->getOrder($orderId);
 
-        $webpayOrderData->setMetadata(json_encode($commitResponse));
+            $transbankSdkWebpay = new TransbankSdkWebpayRest($config);
+            $commitResponse = $transbankSdkWebpay->commitTransaction($token);
 
-        $responseHandled = null;
+            if (is_array($commitResponse) && isset($commitResponse['error'])) {
+                return $this->handleFlowError($token);
+            }
 
-        if ($commitResponse->isApproved()) {
-            $responseHandled = $this->handleAuthorizedTransaction($order, $webpayOrderData, $commitResponse);
-        } else {
-            $responseHandled = $this->handleUnauthorizedTransaction($order, $webpayOrderData, $commitResponse);
+            $webpayOrderData->setMetadata(json_encode($commitResponse));
+
+            if ($commitResponse->isApproved()) {
+                $responseHandled = $this->handleAuthorizedTransaction($order, $webpayOrderData, $commitResponse);
+            } else {
+                $responseHandled = $this->handleUnauthorizedTransaction($order, $webpayOrderData, $commitResponse);
+            }
+        } finally {
+            $this->releaseWebpayReturnLock($token, $lockAcquired);
         }
 
         return $responseHandled;
+    }
+
+    /**
+     * Tries to acquire the return lock for a token.
+     *
+     * @param string $token
+     * @return bool True when the lock is acquired, false when another request is already processing.
+     */
+    private function acquireWebpayReturnLock(string $token): bool
+    {
+        $lockAcquired = false;
+
+        try {
+            $lockAcquired = $this->webpayReturnLock->acquire($token);
+
+            if (!$lockAcquired) {
+                $this->log->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
+            }
+        } catch (\Throwable $e) {
+            $this->log->logError("Error al adquirir el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
+        }
+
+        return $lockAcquired;
+    }
+
+    /**
+     * Releases the return lock only when it was actually acquired.
+     *
+     * @param string $token
+     * @param bool $lockAcquired
+     * @return void
+     */
+    private function releaseWebpayReturnLock(string $token, bool $lockAcquired): void
+    {
+        if (!$lockAcquired) {
+            return;
+        }
+
+        try {
+            $released = $this->webpayReturnLock->release($token);
+
+            if (!$released) {
+                $this->log->logWarning("No se pudo liberar el lock de retorno de Webpay token => {$token}");
+            }
+        } catch (\Throwable $e) {
+            $this->log->logWarning("Error al liberar el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
+        }
     }
 
     private function handleFlowTimeout(string $buyOrder)

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -208,17 +208,13 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
      */
     private function acquireWebpayReturnLock(string $token): bool
     {
-        try {
-            $lockAcquired = $this->webpayReturnLock->acquire($token);
+        $lockAcquired = $this->webpayReturnLock->acquire($token);
 
-            if (!$lockAcquired) {
-                $this->log->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
-            }
-
-            return $lockAcquired;
-        } catch (\Throwable $e) {
-            $this->log->logError("Error al adquirir el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
+        if (!$lockAcquired) {
+            $this->log->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
         }
+
+        return $lockAcquired;
     }
 
     /**
@@ -240,7 +236,7 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
             if (!$released) {
                 $this->log->logWarning("No se pudo liberar el lock de retorno de Webpay token => {$token}");
             }
-        } catch (\Throwable $e) {
+        } catch (MySqlNamedLockException $e) {
             $this->log->logError("Error al liberar el lock de retorno de Webpay token => {$token} - Error: {$e->getMessage()}");
         }
     }

--- a/Controller/Transaction/CommitWebpay.php
+++ b/Controller/Transaction/CommitWebpay.php
@@ -208,13 +208,18 @@ class CommitWebpay extends \Magento\Framework\App\Action\Action
      */
     private function acquireWebpayReturnLock(string $token): bool
     {
-        $lockAcquired = $this->webpayReturnLock->acquire($token);
+        try {
+            $lockAcquired = $this->webpayReturnLock->acquire($token);
 
-        if (!$lockAcquired) {
-            $this->log->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
+            if (!$lockAcquired) {
+                $this->log->logInfo("Retorno de Webpay ya se encuentra en procesamiento => token: {$token}");
+            }
+
+            return $lockAcquired;
+        } catch (\Throwable $e) {
+            $this->log->logError("Error al adquirir el lock de retorno de Webpay => token: {$token} - Error: {$e->getMessage()}");
+            throw $e;
         }
-
-        return $lockAcquired;
     }
 
     /**

--- a/Exceptions/MySqlNamedLockException.php
+++ b/Exceptions/MySqlNamedLockException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Transbank\Webpay\Exceptions;
+
+use RuntimeException;
+
+class MySqlNamedLockException extends RuntimeException {}

--- a/Helper/ILogger.php
+++ b/Helper/ILogger.php
@@ -7,6 +7,7 @@ interface ILogger
     function logInfo(string $str): void;
     function logError(string $str): void;
     function logDebug(string $str): void;
+    function logWarning(string $str): void;
     function getInfo(): array;
     function getLogDetail(string $filename, bool $replaceNewline): array;
 }

--- a/Helper/PluginLogger.php
+++ b/Helper/PluginLogger.php
@@ -87,6 +87,11 @@ class PluginLogger implements ILogger
         $this->logger->error($msg);
     }
 
+    public function logWarning(string $msg): void
+    {
+        $this->logger->warning($msg);
+    }
+
     /**
      * Retrieve information about log files.
      *

--- a/Infrastructure/Lock/MySqlNamedLock.php
+++ b/Infrastructure/Lock/MySqlNamedLock.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Transbank\Webpay\Infrastructure\Lock;
+
+use Magento\Framework\App\ResourceConnection;
+use Transbank\Webpay\Exceptions\MySqlNamedLockException;
+
+/**
+ * Thin MySQL named lock adapter.
+ *
+ * It provides a reusable acquire/release primitive for flows that need to serialize work by key.
+ */
+class MySqlNamedLock
+{
+    private const LOCK_PREFIX = 'transbank_webpay_lock_';
+
+    private $connection;
+
+    public function __construct(ResourceConnection $resource)
+    {
+        $this->connection = $resource->getConnection();
+    }
+
+    public function acquire(string $key): bool
+    {
+        $lockName = $this->buildLockName($key);
+        $result = $this->connection->fetchOne('SELECT GET_LOCK(?, 0)', [$lockName]);
+
+        if ($result === null) {
+            throw new MySqlNamedLockException(
+                'No se pudo adquirir el lock de retorno de Webpay: error al consultar la base de datos.'
+            );
+        }
+
+        return $result === '1';
+    }
+
+    public function release(string $key): bool
+    {
+        $lockName = $this->buildLockName($key);
+        $result = $this->connection->fetchOne('SELECT RELEASE_LOCK(?)', [$lockName]);
+
+        if ($result === null) {
+            throw new MySqlNamedLockException(
+                'No se pudo liberar el lock de retorno de Webpay: error al consultar la base de datos.'
+            );
+        }
+
+        return $result === '1';
+    }
+
+    private function buildLockName(string $key): string
+    {
+        return self::LOCK_PREFIX . substr(hash('sha256', $key), 0, 40);
+    }
+}

--- a/Observer/RefundObserver.php
+++ b/Observer/RefundObserver.php
@@ -95,7 +95,6 @@ class RefundObserver implements ObserverInterface
             $this->orderRepository->save($order);
             $this->messageManager->addErrorMessage($errorMessageBase . $refundInstructions);
             return;
-
         } catch (\Exception $exception) {
             $errorMessage = $errorMessageBase . $exception->getMessage() . '. ' . $refundInstructions;
             $this->logger->logError($errorMessage);
@@ -103,16 +102,6 @@ class RefundObserver implements ObserverInterface
             $this->orderRepository->save($order);
             $this->messageManager->addErrorMessage($errorMessageBase . $refundInstructions);
         }
-    }
-
-    /**
-     * @param string $paymentMethod
-     *
-     * @return bool
-     */
-    private function shouldProcessRefund($paymentMethod): bool
-    {
-        return $paymentMethod == Webpay::CODE || $paymentMethod == OneClick::CODE;
     }
 
     /**
@@ -126,7 +115,6 @@ class RefundObserver implements ObserverInterface
             return $this->configProvider->getPluginConfig();
         }
         return $this->configProvider->getPluginConfigOneclick();
-
     }
 
     /**
@@ -225,5 +213,4 @@ class RefundObserver implements ObserverInterface
 
         return $message;
     }
-
 }


### PR DESCRIPTION
This PR refines the Webpay commit workflow to safely handle concurrent return requests.

When Webpay sends multiple return calls for the same transaction, only the first request is allowed to continue through the normal commit flow. Any concurrent duplicate requests are intentionally aborted early by a lock to prevent double processing.

This is expected behavior: the user only sees the first return flow, while the other requests occur backend-to-backend and should be ignored once processing is already in progress.

If the first request acquires the lock but later fails, the error is handled through the normal error flow. This keeps the control flow consistent and lets the existing error handling mechanisms decide the final outcome.

The change helps prevent race conditions, duplicate commits, and inconsistent payment states.

## Test

- Success
<img width="3358" height="1872" alt="Success" src="https://github.com/user-attachments/assets/456dfff2-0a3a-4424-aacb-db474f15f9f4" />

- Error
<img width="3400" height="2042" alt="Error" src="https://github.com/user-attachments/assets/b8c03a50-5bc1-4057-bcfc-4362009664e3" />
